### PR TITLE
[Refactor] 공통 버튼 재사용성 및 확장성 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "react-router-dom": "^7.6.3",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -5659,6 +5660,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/components/CommonButton.tsx
+++ b/src/components/CommonButton.tsx
@@ -1,13 +1,34 @@
 import React from "react";
-import BackIcon from "../assets/Icons/BackIcon.svg";
+import { twMerge } from "tailwind-merge";
+
+type CommonButtonProps = {
+  children: React.ReactNode; // 버튼 안에 들어갈 텍스트 혹은 다른 React 요소
+  icon?: React.ReactElement<{ className?: string }>; // 아이콘을 선택적으로 받을 수 있도록 추가
+  className?: string; // tailwind-merge를 위해 className을 명시적으로 추가
+  onClick?: () => void;
+};
 
 // 1rem = 16px
-const CommonButton: React.FC = () => {
+const CommonButton: React.FC<CommonButtonProps> = ({
+  children,
+  icon,
+  className,
+}) => {
+  const iconWithClassName = icon
+    ? React.cloneElement(icon, { className: "w-[20px] h-[20px]" })
+    : null;
+
   return (
-    // align-items:center -> items-center (tailwind버전)
-    <button className="flex flex-row justify-center gap-[20px] items-center w-[17.5rem] h-[4rem] bg-[#FCFAF7] text-black rounded-full shadow-md">
-      <img src={BackIcon} className="w-[20px] h-[20px]" />
-      <span className="text-[20px] text-lg font-bold">대본으로 돌아가기</span>
+    // (CSS) align-items:center -> (tailwind) items-center
+    <button
+      className={twMerge(
+        "flex flex-row justify-center gap-[1.25rem] items-center w-[17.5rem] h-[4rem] bg-[#FCFAF7] text-black rounded-full shadow-md",
+        className
+      )}
+      onClick={() => {}}
+    >
+      {iconWithClassName}
+      <span className="text-[20px] text-lg font-bold">{children}</span>
     </button>
   );
 };

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -3,12 +3,15 @@ import CommonButton from "../components/CommonButton";
 import ThumbnailFetch from "../components/ThumbnailFetch";
 import Toggle from "../components/Toggle";
 import VideoInfoFetch from "../components/VideoInfoFetch";
+import BackIcon from "../assets/Icons/BackIcon.svg";
 
 const MyLibrary: React.FC = () => {
   return (
     <div>
       <Toggle />
-      <CommonButton />
+      <CommonButton icon={<img src={BackIcon} />}>
+        대본으로 돌아가기
+      </CommonButton>
       <ThumbnailFetch />
       <VideoInfoFetch />
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> [Refactor] 공통 버튼 재사용성 및 확장성 개선 #13   

## 📝작업 내용

1. 동적 텍스트 적용
{children} 속성 이용해서 공통컴포넌트를 수정하지않고도 불러오는 파일에서 button 내부의 텍스트를 변경 가능하도록 구현

2. 동적 아이콘 적용
아이콘을 입력받을 수 있게 구현 및 크기가 자동으로 고정되게 구현

4. 클래스 병합 기능 구현
tailwind-merge를 써서 버튼을 불러오는 컴포넌트/페이지에서 버튼 폭과 배경색 등을 props로 변경할 수 있게 구현(className)