### PR TITLE
[Design] 로그인/회원가입 페이지 퍼블리싱

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import MainLayout from "./Layouts/MainLayout";
 import MyLibrary from "./pages/MyLibraryPage";
 import MyVideos from "./pages/MyVideosPage"; // Assuming you have a MyVideos component
+import AuthLayout from "./Layouts/AuthLayout";
 
 const App: React.FC = () => {
   return (
@@ -26,6 +27,7 @@ const App: React.FC = () => {
             </MainLayout>
           }
         />
+        <Route path="/auth" element={<AuthLayout>ㅇㅇ</AuthLayout>} />
       </Routes>
     </Router>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ const App: React.FC = () => {
             </MainLayout>
           }
         />
-        <Route path="/auth" element={<AuthLayout>ㅇㅇ</AuthLayout>} />
+        <Route path="/auth" element={<AuthLayout />} />
       </Routes>
     </Router>
   );

--- a/src/Layouts/AuthLayout.tsx
+++ b/src/Layouts/AuthLayout.tsx
@@ -1,15 +1,69 @@
-import React from "react";
-import Header from "../components/Header";
+// src/Layouts/AuthLayout.tsx
 
-type AuthLayoutProps = {
-  children: React.ReactNode;
-};
+import React, { useState, useEffect } from "react";
+import LoginView from "../components/LoginView";
+import SignupView from "../components/SignupView";
 
-const AuthLayout: React.FC<AuthLayoutProps> = ({ children }) => {
+const AuthLayout: React.FC = () => {
+  const [view, setView] = useState<"login" | "signup">("login");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const mode = params.get("mode");
+    if (mode === "signup") {
+      setView("signup");
+    }
+  }, []);
+
   return (
-    <div className="flex flex-col min-h-screen w-full bg-[#F8F3ED] border border-black">
-      <Header />
-      <main className="flex flex-1 justify-center">{children}</main>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#FBF9F4] p-8 font-['Noto_Sans_KR'] text-[#3D3D3D]">
+      {/* 로고 */}
+      <div
+        className="mb-8 cursor-pointer text-center"
+        onClick={() => (window.location.href = "/")}
+      >
+        {/* 로고와 텍스트를 가로로 정렬하기 위해 flex 사용 */}
+        <div className="flex flex-col items-center justify-center">
+          <svg
+            className="mx-auto h-12 w-12 text-[#C0842B]"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M4 6C4 4.89543 4.89543 4 6 4H18C19.1046 4 20 4.89543 20 6V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18V6Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M9 4V20"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M13 10L17 12L13 14V10Z"
+              fill="currentColor"
+              stroke="currentColor"
+              strokeWidth="1"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span className="mt-2 text-3xl font-bold font-['Lora']">EPILOG</span>
+        </div>
+      </div>
+
+      <div className="w-full max-w-md rounded-3xl border border-black/5 bg-[#FBF9F4] p-10 shadow-xl">
+        {view === "login" ? (
+          <LoginView onSwitchToSignup={() => setView("signup")} />
+        ) : (
+          <SignupView onSwitchToLogin={() => setView("login")} />
+        )}
+      </div>
     </div>
   );
 };

--- a/src/Layouts/AuthLayout.tsx
+++ b/src/Layouts/AuthLayout.tsx
@@ -23,11 +23,7 @@ const AuthLayout: React.FC = () => {
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#FBF9F4] p-8 font-['Noto_Sans_KR'] text-[#3D3D3D]">
       <Link to="/" className="mb-8 cursor-pointer text-center">
         <div className="flex items-center justify-center">
-          <img
-            src={Logo}
-            alt="EPILOG Logo"
-            className="mx-4 w-[2rem] text-[#3D3D3D]"
-          />
+          <img src={Logo} alt="EPILOG Logo" className="mx-4 w-[2rem]" />
           <span className="text-[2rem] font-bold font-crimson">EPILOG</span>
         </div>
       </Link>

--- a/src/Layouts/AuthLayout.tsx
+++ b/src/Layouts/AuthLayout.tsx
@@ -3,6 +3,10 @@
 import React, { useState, useEffect } from "react";
 import LoginView from "../components/LoginView";
 import SignupView from "../components/SignupView";
+import { Link } from "react-router-dom";
+
+// icons
+import Logo from "../assets/icons/Logo.svg"; // Assuming you have a logo image in this path
 
 const AuthLayout: React.FC = () => {
   const [view, setView] = useState<"login" | "signup">("login");
@@ -17,45 +21,16 @@ const AuthLayout: React.FC = () => {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#FBF9F4] p-8 font-['Noto_Sans_KR'] text-[#3D3D3D]">
-      {/* 로고 */}
-      <div
-        className="mb-8 cursor-pointer text-center"
-        onClick={() => (window.location.href = "/")}
-      >
-        {/* 로고와 텍스트를 가로로 정렬하기 위해 flex 사용 */}
-        <div className="flex flex-col items-center justify-center">
-          <svg
-            className="mx-auto h-12 w-12 text-[#C0842B]"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M4 6C4 4.89543 4.89543 4 6 4H18C19.1046 4 20 4.89543 20 6V18C20 19.1046 19.1046 20 18 20H6C4.89543 20 4 19.1046 4 18V6Z"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M9 4V20"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M13 10L17 12L13 14V10Z"
-              fill="currentColor"
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span className="mt-2 text-3xl font-bold font-['Lora']">EPILOG</span>
+      <Link to="/" className="mb-8 cursor-pointer text-center">
+        <div className="flex items-center justify-center">
+          <img
+            src={Logo}
+            alt="EPILOG Logo"
+            className="mx-4 w-[2rem] text-[#3D3D3D]"
+          />
+          <span className="text-[2rem] font-bold font-crimson">EPILOG</span>
         </div>
-      </div>
+      </Link>
 
       <div className="w-full max-w-md rounded-3xl border border-black/5 bg-[#FBF9F4] p-10 shadow-xl">
         {view === "login" ? (

--- a/src/Layouts/AuthLayout.tsx
+++ b/src/Layouts/AuthLayout.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Header from "../components/Header";
+
+type AuthLayoutProps = {
+  children: React.ReactNode;
+};
+
+const AuthLayout: React.FC<AuthLayoutProps> = ({ children }) => {
+  return (
+    <div className="flex flex-col min-h-screen w-full bg-[#F8F3ED] border border-black">
+      <Header />
+      <main className="flex flex-1 justify-center">{children}</main>
+    </div>
+  );
+};
+
+export default AuthLayout;

--- a/src/assets/Icons/Logo.svg
+++ b/src/assets/Icons/Logo.svg
@@ -1,5 +1,5 @@
 <svg width="37" height="36" viewBox="0 0 37 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2.30469 6C2.30469 3.79086 4.09555 2 6.30469 2H30.3047C32.5139 2 34.3047 3.79086 34.3047 6V30C34.3047 32.2092 32.5139 34 30.3047 34H6.30469C4.09555 34 2.30469 32.2092 2.30469 30V6Z" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.707 2V34" stroke="black" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M19.8203 14L27.8203 18L19.8203 22V14Z" fill="black" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.30469 6C2.30469 3.79086 4.09555 2 6.30469 2H30.3047C32.5139 2 34.3047 3.79086 34.3047 6V30C34.3047 32.2092 32.5139 34 30.3047 34H6.30469C4.09555 34 2.30469 32.2092 2.30469 30V6Z" stroke="#3D3D3D" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.707 2V34" stroke="#3D3D3D" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.8203 14L27.8203 18L19.8203 22V14Z" fill="#3D3D3D" stroke="#3D3D3D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/components/LoginView.tsx
+++ b/src/components/LoginView.tsx
@@ -1,16 +1,19 @@
 // src/components/LoginView.tsx
 
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 interface LoginViewProps {
   onSwitchToSignup: () => void;
 }
 
 const LoginView: React.FC<LoginViewProps> = ({ onSwitchToSignup }) => {
+  const navigate = useNavigate();
   const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     alert("로그인 성공! 메인 페이지로 이동합니다.");
-    // window.location.href = '/main';
+    // window.location.href 대신 navigate 함수 사용
+    navigate("/");
   };
 
   return (

--- a/src/components/LoginView.tsx
+++ b/src/components/LoginView.tsx
@@ -1,0 +1,60 @@
+// src/components/LoginView.tsx
+
+import React from "react";
+
+interface LoginViewProps {
+  onSwitchToSignup: () => void;
+}
+
+const LoginView: React.FC<LoginViewProps> = ({ onSwitchToSignup }) => {
+  const handleLogin = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    alert("로그인 성공! 메인 페이지로 이동합니다.");
+    // window.location.href = '/main';
+  };
+
+  return (
+    <div className="auth-view active">
+      <div className="mb-8 text-center">
+        <h2 className="font-serif text-2xl font-bold">다시 오신 걸 환영해요</h2>
+        <p className="mt-2 text-gray-500">
+          당신의 이야기를 계속 이어가 보세요.
+        </p>
+      </div>
+      <form onSubmit={handleLogin}>
+        <div className="flex flex-col space-y-4">
+          <input
+            type="email"
+            placeholder="이메일"
+            className="w-full rounded-xl border border-[#E6DBCB] bg-white p-3 transition focus:border-[#C0842B] focus:outline-none focus:ring-2 focus:ring-[#C0842B]/30"
+            required
+          />
+          <input
+            type="password"
+            placeholder="비밀번호"
+            className="w-full rounded-xl border border-[#E6DBCB] bg-white p-3 transition focus:border-[#C0842B] focus:outline-none focus:ring-2 focus:ring-[#C0842B]/30"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="mt-8 w-full rounded-xl bg-[#C0842B] py-3 font-semibold text-white transition hover:opacity-90"
+        >
+          로그인
+        </button>
+        <p className="mt-6 text-center text-sm">
+          계정이 없으신가요?{" "}
+          <button
+            type="button"
+            onClick={onSwitchToSignup}
+            className="font-semibold text-[#C0842B] hover:underline"
+          >
+            회원가입
+          </button>
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default LoginView;

--- a/src/components/SignupView.tsx
+++ b/src/components/SignupView.tsx
@@ -1,0 +1,73 @@
+// src/components/SignupView.tsx
+
+import React from "react";
+
+interface SignupViewProps {
+  onSwitchToLogin: () => void;
+}
+
+const SignupView: React.FC<SignupViewProps> = ({ onSwitchToLogin }) => {
+  const handleSignup = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    alert("회원가입 성공! 메인 페이지로 이동합니다.");
+    // window.location.href = '/main';
+  };
+
+  return (
+    <div className="auth-view active">
+      <div className="mb-8 text-center">
+        <h2 className="font-serif text-2xl font-bold">
+          이야기의 끝을 기록해 보세요
+        </h2>
+        <p className="mt-2 text-gray-500">
+          EPILOG와 함께라면 당신도 작가가 될 수 있어요.
+        </p>
+      </div>
+      <form onSubmit={handleSignup}>
+        <div className="flex flex-col space-y-4">
+          <input
+            type="email"
+            placeholder="이메일"
+            className="w-full rounded-xl border border-[#E6DBCB] bg-white p-3 transition focus:border-[#C0842B] focus:outline-none focus:ring-2 focus:ring-[#C0842B]/30"
+            required
+          />
+          <input
+            type="password"
+            placeholder="비밀번호"
+            className="w-full rounded-xl border border-[#E6DBCB] bg-white p-3 transition focus:border-[#C0842B] focus:outline-none focus:ring-2 focus:ring-[#C0842B]/30"
+            required
+          />
+          <input
+            type="text"
+            placeholder="닉네임"
+            className="w-full rounded-xl border border-[#E6DBCB] bg-white p-3 transition focus:border-[#C0842B] focus:outline-none focus:ring-2 focus:ring-[#C0842B]/30"
+            required
+          />
+          <textarea
+            placeholder="자신을 나타내는 한 줄 소개를 적어보세요."
+            className="h-24 w-full resize-none rounded-xl border border-[#E6DBCB] bg-white p-3 transition focus:border-[#C0842B] focus:outline-none focus:ring-2 focus:ring-[#C0842B]/30"
+            maxLength={100}
+          ></textarea>
+        </div>
+        <button
+          type="submit"
+          className="mt-8 w-full rounded-xl bg-[#C0842B] py-3 font-semibold text-white transition hover:opacity-90"
+        >
+          회원가입
+        </button>
+        <p className="mt-6 text-center text-sm">
+          이미 계정이 있으신가요?{" "}
+          <button
+            type="button"
+            onClick={onSwitchToLogin}
+            className="font-semibold text-[#C0842B] hover:underline"
+          >
+            로그인
+          </button>
+        </p>
+      </form>
+    </div>
+  );
+};
+
+export default SignupView;

--- a/src/components/SignupView.tsx
+++ b/src/components/SignupView.tsx
@@ -1,16 +1,20 @@
 // src/components/SignupView.tsx
 
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 interface SignupViewProps {
   onSwitchToLogin: () => void;
 }
 
 const SignupView: React.FC<SignupViewProps> = ({ onSwitchToLogin }) => {
+  const navigate = useNavigate(); // useNavigate 훅 선언
+
   const handleSignup = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     alert("회원가입 성공! 메인 페이지로 이동합니다.");
-    // window.location.href = '/main';
+    // 변경점: window.location.href 대신 navigate 함수 사용
+    navigate("/");
   };
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  .auth-view {
+    animation: fadeIn 0.5s ease;
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}
 /* html,
 body,
 #root {


### PR DESCRIPTION
## #️⃣연관된 이슈

> [Design] 로그인/회원가입 페이지 퍼블리싱 #12   

## 📝작업 내용

1. 로그인/회원가입 페이지 퍼블리싱
AuthLayout으로 따로 레이아웃 구성 및 useNavigate 로 페이지 이동

2. 간단한 입력값 유효성 검사 수행 

3. 로고 색상 변경

### 스크린샷
![auth페이지퍼블리싱](https://github.com/user-attachments/assets/83ed7c16-7b34-45fd-8a3b-3a67712d91f9)


### 개선할 점 / 더 해야할 작업
- 로그인/회원가입 멘트 수정
- 백엔드에서 한 것처럼 유효성 검사 로직 추가 반영 
- API 연동