### PR TITLE
[Feat] 내 서재 페이지 API 연동

### DIFF
--- a/src/api/bookApi.ts
+++ b/src/api/bookApi.ts
@@ -1,0 +1,58 @@
+import axios from "axios";
+import { ENDPOINTS } from "../constants/api";
+
+// API 응답 타입 정의
+export interface BookApiResponse {
+  book_id: number;
+  title: string;
+  content: string;
+  pdf_url: string;
+}
+
+export interface VideoApiResponse {
+  video_id: number;
+  character_id: number;
+  video_url: string;
+  thumbnail_url: string;
+}
+
+// 공식 책 목록 조회
+export const getOfficialBooks = async (): Promise<BookApiResponse[]> => {
+  try {
+    const response = await axios.get<BookApiResponse[]>(
+      ENDPOINTS.books.getOfficial
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Failed to fetch official books:", error);
+    throw error;
+  }
+};
+
+// 개인 업로드 책 목록 조회
+export const getPersonalBooks = async (): Promise<BookApiResponse[]> => {
+  try {
+    const response = await axios.get<BookApiResponse[]>(
+      ENDPOINTS.books.getPersonal
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Failed to fetch personal books:", error);
+    throw error;
+  }
+};
+
+// 특정 책의 영상 목록 조회
+export const getVideosByBookId = async (
+  bookId: number
+): Promise<VideoApiResponse[]> => {
+  try {
+    const response = await axios.get<VideoApiResponse[]>(
+      ENDPOINTS.videos.getByBookId(bookId.toString())
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`Failed to fetch videos for book ${bookId}:`, error);
+    throw error;
+  }
+};

--- a/src/api/bookApi.ts
+++ b/src/api/bookApi.ts
@@ -16,7 +16,16 @@ export interface VideoApiResponse {
   thumbnail_url: string;
 }
 
-// 공식 책 목록 조회
+export interface CharacterApiResponse {
+  character_id: number;
+  character_name: string;
+  is_main: boolean;
+  age: number;
+  gender: string;
+  character_description: string;
+}
+
+// 공식 책 목록 조회 (GET /books/official)
 export const getOfficialBooks = async (): Promise<BookApiResponse[]> => {
   try {
     const response = await axios.get<BookApiResponse[]>(
@@ -53,6 +62,21 @@ export const getVideosByBookId = async (
     return response.data;
   } catch (error) {
     console.error(`Failed to fetch videos for book ${bookId}:`, error);
+    throw error;
+  }
+};
+
+// 특정 책의 캐릭터 목록 조회 (GET /books/{bookId}/characters)
+export const getCharactersByBookId = async (
+  bookId: number
+): Promise<CharacterApiResponse[]> => {
+  try {
+    const response = await axios.get<CharacterApiResponse[]>(
+      ENDPOINTS.characters.getByBookId(bookId.toString())
+    );
+    return response.data;
+  } catch (error) {
+    console.error(`Failed to fetch characters for book ${bookId}:`, error);
     throw error;
   }
 };

--- a/src/components/ActCharacterCard.tsx
+++ b/src/components/ActCharacterCard.tsx
@@ -2,27 +2,78 @@ import React, { useState, useEffect } from "react";
 import FrontCharacterCard from "./FrontCharacterCard";
 import BackCharacterCard from "./BackCharacterCard";
 
+// API 응답 타입 (bookApi.ts에서 정의된 것과 동일)
+type ApiCharacterType = {
+  character_id: number;
+  character_name: string;
+  is_main: boolean;
+  age: number;
+  gender: string;
+  character_description: string;
+};
+
+// UI에서 사용할 타입 (기존 JSON 형식과 호환)
 type CharacterType = {
   name: string;
   sex: string;
   description: string;
 };
 
-const ActCharacterCard: React.FC = () => {
+interface ActCharacterCardProps {
+  characters?: ApiCharacterType[]; // API에서 받은 캐릭터 데이터 (optional)
+}
+
+const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
+  characters: apiCharacters,
+}) => {
   const [characters, setCharacters] = useState<CharacterType[]>([]);
   const [flipped, setFlipped] = useState<boolean[]>([]);
 
-  // json 파일에서 캐릭터 데이터 불러오기
+  // API 데이터 또는 JSON 파일에서 캐릭터 데이터 불러오기
   useEffect(() => {
-    fetch("/SampleCharacterCard.json")
-      .then((res) => res.json())
-      .then((data) => {
-        setCharacters(data);
-        setFlipped(Array(data.length).fill(false));
-      });
-  }, []);
+    if (apiCharacters && apiCharacters.length > 0) {
+      // API에서 받은 데이터를 UI 형식으로 변환
+      const transformedCharacters: CharacterType[] = apiCharacters.map(
+        (char) => ({
+          name: char.character_name,
+          sex:
+            char.gender === "male"
+              ? "남성"
+              : char.gender === "female"
+                ? "여성"
+                : char.gender,
+          description: char.character_description,
+        })
+      );
 
-  if (characters.length === 0) return <div>로딩중...</div>;
+      setCharacters(transformedCharacters);
+      setFlipped(Array(transformedCharacters.length).fill(false));
+    } else {
+      // fallback: JSON 파일에서 캐릭터 데이터 불러오기
+      fetch("/SampleCharacterCard.json")
+        .then((res) => res.json())
+        .then((data) => {
+          setCharacters(data);
+          setFlipped(Array(data.length).fill(false));
+        })
+        .catch((error) => {
+          console.error("Failed to fetch sample characters:", error);
+          setCharacters([]);
+          setFlipped([]);
+        });
+    }
+  }, [apiCharacters]);
+
+  if (characters.length === 0) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#DCAC62] mx-auto mb-4"></div>
+          <p className="text-lg text-gray-600">등장인물을 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
 
   const handleFlip = (idx: number) => {
     setFlipped((prevFlipped) => {

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -96,7 +96,7 @@ const CharacterSelectPage: React.FC = () => {
           <CommonButton
             icon={<img src={BackIcon} alt="뒤로가기" className="mr-2" />}
             className="w-[280px] h-[60px] mb-11 mt-10"
-            onClick={() => navigate("/main")}
+            onClick={() => navigate("/")}
           >
             <span className="text-[20px]">내 서재로 돌아가기</span>
           </CommonButton>

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import Header from "../components/Header";
 import ActCharacterCard from "../components/ActCharacterCard";
 import CommonButton from "../components/CommonButton";
@@ -11,10 +11,22 @@ import ConfirmModal from "../components/ConfirmModal";
 
 const CharacterSelectPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [showMore, setShowMore] = useState(false);
   const [modalName, setModalName] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+
+  // MyLibraryPage에서 전달받은 캐릭터 데이터
+  const { characters, bookTitle } = location.state || {};
+
+  // 캐릭터 데이터가 없으면 MyLibrary로 리다이렉트
+  useEffect(() => {
+    if (!characters || !bookTitle) {
+      alert("잘못된 접근입니다. 책을 선택해주세요.");
+      navigate("/");
+    }
+  }, [characters, bookTitle, navigate]);
 
   const handleConfirm = () => {
     setModalVisible(false); // 먼저 숨기기
@@ -56,7 +68,8 @@ const CharacterSelectPage: React.FC = () => {
             주인공 선택하기
           </div>
           <div className="mt-1 mb-2 text-base text-[#868686] font-NanumMyeongjo">
-            브이로그의 주인공이 될 등장인물을 선택해주세요.
+            {bookTitle ? `『${bookTitle}』의 등장인물 중에서 ` : ""}브이로그의
+            주인공이 될 등장인물을 선택해주세요.
           </div>
         </div>
 
@@ -69,7 +82,7 @@ const CharacterSelectPage: React.FC = () => {
         >
           {/* 캐릭터 카드 리스트 */}
           <div className="py-10">
-            <ActCharacterCard />
+            <ActCharacterCard characters={characters} />
           </div>
 
           {/* 인물 더보기 + 안내문구 */}

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
 import BooksSection from "../components/BooksSection";
-import { ENDPOINTS } from "../constants/api";
 import { useAuth } from "../hooks/useAuth";
+import { getOfficialBooks, getVideosByBookId } from "../api/bookApi";
+import type { BookApiResponse, VideoApiResponse } from "../api/bookApi";
 
 // assets
 import BookFloor from "../assets/Images/BookFloor.svg";
@@ -18,17 +18,11 @@ interface Book {
   title: string;
 }
 
-// API 응답 타입
-interface BookApiResponse {
-  book_id: number;
-  title: string;
-  content: string;
-  pdf_url: string;
-}
-
-// 영상 데이터 타입
+// 영상 데이터 타입 (API 응답을 UI에 맞게 변환된 형태)
 interface VideoData {
   imageUrl: string;
+  videoUrl: string;
+  videoId: number;
 }
 
 // 한글 조사 처리 함수
@@ -79,20 +73,21 @@ const MyLibraryPage: React.FC = () => {
   const [books, setBooks] = useState<Book[]>([]);
   // 책 목록 로딩 상태
   const [booksLoading, setBooksLoading] = useState(true);
+  // 영상 목록 데이터
+  const [videos, setVideos] = useState<VideoData[]>([]);
+  // 영상 목록 로딩 상태
+  const [videosLoading, setVideosLoading] = useState(false);
 
   useEffect(() => {
     const fetchBooks = async () => {
       try {
         setBooksLoading(true); // 로딩 상태 시작
 
-        // axios를 사용하여 공식 책 목록 API 호출
-        const response = await axios.get<BookApiResponse[]>(
-          ENDPOINTS.books.getOfficial
-        );
-        const data = response.data;
+        // bookApi를 사용하여 공식 책 목록 API 호출
+        const data = await getOfficialBooks();
 
         // API 응답을 Book 타입(interface)에 맞게 변환
-        const transformedBooks: Book[] = data.map((book) => ({
+        const transformedBooks: Book[] = data.map((book: BookApiResponse) => ({
           id: book.book_id, // book_id -> id 매핑
           src:
             book.pdf_url || // PDF URL이 있으면 사용, 없으면 플레이스홀더 이미지
@@ -115,26 +110,43 @@ const MyLibraryPage: React.FC = () => {
     fetchBooks(); // 함수 실행
   }, []); // 의존성 배열이 빈 배열이 컴포넌트 마운트 시에만 실행
 
-  // 각 책별 영상 데이터 (book_id 기준)
-  const videoDataByBook: Record<number, VideoData[]> = {
-    1: [
-      // 노인과 바다
-      { imageUrl: "https://picsum.photos/400/200?random=1" },
-      { imageUrl: "https://picsum.photos/400/200?random=2" },
-    ],
-    2: [
-      // 린어공주
-      { imageUrl: "https://picsum.photos/400/200?random=3" },
-    ],
-    3: [], // 1984 - 영상 없음
-  };
-
   // 현재 선택된 책 객체
   const selectedBook = books[selectedBookIndex];
-  // 선택된 책에 해당하는 영상 목록 (없으면 빈 배열)
-  const selectedBookVideos = selectedBook
-    ? videoDataByBook[selectedBook.id] || []
-    : [];
+
+  // 선택된 책의 영상 목록 조회
+  useEffect(() => {
+    const fetchVideos = async () => {
+      if (!selectedBook) {
+        setVideos([]);
+        return;
+      }
+
+      try {
+        setVideosLoading(true);
+        const videoData = await getVideosByBookId(selectedBook.id);
+
+        // API 응답을 VideoData 타입에 맞게 변환
+        const transformedVideos: VideoData[] = videoData.map(
+          (video: VideoApiResponse) => ({
+            videoId: video.video_id,
+            videoUrl: video.video_url,
+            imageUrl: video.thumbnail_url,
+          })
+        );
+
+        setVideos(transformedVideos);
+      } catch (error) {
+        console.error("Failed to fetch videos:", error);
+        setVideos([]);
+      } finally {
+        setVideosLoading(false);
+      }
+    };
+
+    fetchVideos();
+  }, [selectedBook]); // selectedBook가 변경될 때마다 실행
+  // 선택된 책에 해당하는 영상 목록
+  const selectedBookVideos = videos;
   // 한글 조사 처리 ("로" 또는 "으로")
   const particle = selectedBook ? getKoreanParticle(selectedBook.title) : "로";
 
@@ -276,7 +288,15 @@ const MyLibraryPage: React.FC = () => {
                 <span className="text-black"> {particle} 만든 VLOG 목록</span>
               </h2>
 
-              {selectedBookVideos.length === 0 ? (
+              {videosLoading ? (
+                // 영상 로딩 중
+                <div className="text-center">
+                  <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#DCAC62] mx-auto mb-4"></div>
+                  <p className="text-[20px] text-gray-600">
+                    영상 목록을 불러오는 중...
+                  </p>
+                </div>
+              ) : selectedBookVideos.length === 0 ? (
                 // 영상이 없는 경우
                 <div className="text-center">
                   <p className="text-[20px] text-gray-600 mb-8">

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -9,6 +9,9 @@ import {
 } from "../api/bookApi";
 import type { BookApiResponse, VideoApiResponse } from "../api/bookApi";
 
+// utils (한글 조사 구분 함수)
+import { getKoreanParticle } from "../utils/koreanUtils";
+
 // assets
 import BookFloor from "../assets/Images/BookFloor.svg";
 import SearchIcon from "../assets/Icons/SearchIcon.svg";
@@ -28,31 +31,6 @@ interface VideoData {
   videoUrl: string;
   videoId: number;
 }
-
-// 한글 조사 처리 함수
-const getKoreanParticle = (word: string): string => {
-  if (!word) return "로";
-
-  const lastChar = word[word.length - 1];
-  const lastCharCode = lastChar.charCodeAt(0);
-
-  // 한글 완성형 문자 범위 확인 (가-힣)
-  if (lastCharCode >= 0xac00 && lastCharCode <= 0xd7a3) {
-    // 받침 확인: (문자코드 - 0xAC00) % 28
-    const finalConsonantIndex = (lastCharCode - 0xac00) % 28;
-
-    // 받침이 없거나 'ㄹ' 받침인 경우 '로' 사용
-    // ㄹ 받침의 인덱스는 8
-    if (finalConsonantIndex === 0 || finalConsonantIndex === 8) {
-      return "로";
-    } else {
-      return "으로";
-    }
-  }
-
-  // 한글이 아닌 경우 기본값
-  return "로";
-};
 
 const MyLibraryPage: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -2,7 +2,11 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import BooksSection from "../components/BooksSection";
 import { useAuth } from "../hooks/useAuth";
-import { getOfficialBooks, getVideosByBookId } from "../api/bookApi";
+import {
+  getOfficialBooks,
+  getVideosByBookId,
+  getCharactersByBookId,
+} from "../api/bookApi";
 import type { BookApiResponse, VideoApiResponse } from "../api/bookApi";
 
 // assets
@@ -163,13 +167,32 @@ const MyLibraryPage: React.FC = () => {
   }
 
   // 영상 생성 클릭 핸들러
-  const handleCreateVideo = () => {
+  const handleCreateVideo = async () => {
+    if (!selectedBook) {
+      alert("책을 선택해주세요.");
+      return;
+    }
+
     setIsLoading(true); // 로딩 화면 표시
 
-    // 1초 후 캐릭터 선택 페이지로 리다이렉트
-    setTimeout(() => {
-      window.location.href = "/char";
-    }, 1000);
+    try {
+      // 선택된 책의 캐릭터 목록 API 호출
+      const charactersData = await getCharactersByBookId(selectedBook.id);
+
+      // API 응답 완료 후 캐릭터 데이터와 함께 페이지 이동
+      navigate("/char", {
+        state: {
+          characters: charactersData,
+          bookTitle: selectedBook.title,
+          bookId: selectedBook.id,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to fetch characters:", error);
+      alert("캐릭터 정보를 불러오는데 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -183,8 +206,8 @@ const MyLibraryPage: React.FC = () => {
               <div className="animate-spin rounded-full h-24 w-24 border-b-2 border-[#DCAC62]"></div>
             </div>
             <p className="text-lg font-semibold text-gray-700 text-center">
-              영상을 만들기 위해, <br />
-              등장 인물을 분석하고 있어요!
+              {selectedBook ? `『${selectedBook.title}』의` : "책의"} <br />
+              등장인물을 분석하고 있어요!
             </p>
             {/* <p className="text-sm text-gray-500 mt-2">잠시만 기다려주세요</p> */}
           </div>

--- a/src/utils/koreanUtils.ts
+++ b/src/utils/koreanUtils.ts
@@ -1,0 +1,104 @@
+/**
+ * 한글 관련 유틸리티 함수들
+ */
+
+/**
+ * 한글 단어의 마지막 글자에 따라 적절한 조사를 반환합니다.
+ * @param word - 조사를 결정할 한글 단어
+ * @returns "로" 또는 "으로"
+ */
+export const getKoreanParticle = (word: string): string => {
+  if (!word) return "로";
+
+  const lastChar = word[word.length - 1];
+  const lastCharCode = lastChar.charCodeAt(0);
+
+  // 한글 완성형 문자 범위 확인 (가-힣)
+  if (lastCharCode >= 0xac00 && lastCharCode <= 0xd7a3) {
+    // 받침 확인: (문자코드 - 0xAC00) % 28
+    const finalConsonantIndex = (lastCharCode - 0xac00) % 28;
+
+    // 받침이 없거나 'ㄹ' 받침인 경우 '로' 사용
+    // ㄹ 받침의 인덱스는 8
+    if (finalConsonantIndex === 0 || finalConsonantIndex === 8) {
+      return "로";
+    } else {
+      return "으로";
+    }
+  }
+
+  // 한글이 아닌 경우 기본값
+  return "로";
+};
+
+/**
+ * 한글 단어에 "을/를" 조사를 붙입니다.
+ * @param word - 조사를 결정할 한글 단어
+ * @returns "을" 또는 "를"
+ */
+export const getObjectParticle = (word: string): string => {
+  if (!word) return "을";
+
+  const lastChar = word[word.length - 1];
+  const lastCharCode = lastChar.charCodeAt(0);
+
+  // 한글 완성형 문자 범위 확인 (가-힣)
+  if (lastCharCode >= 0xac00 && lastCharCode <= 0xd7a3) {
+    // 받침 확인: (문자코드 - 0xAC00) % 28
+    const finalConsonantIndex = (lastCharCode - 0xac00) % 28;
+
+    // 받침이 없으면 "를", 있으면 "을"
+    return finalConsonantIndex === 0 ? "를" : "을";
+  }
+
+  // 한글이 아닌 경우 기본값
+  return "을";
+};
+
+/**
+ * 한글 단어에 "이/가" 조사를 붙입니다.
+ * @param word - 조사를 결정할 한글 단어
+ * @returns "이" 또는 "가"
+ */
+export const getSubjectParticle = (word: string): string => {
+  if (!word) return "이";
+
+  const lastChar = word[word.length - 1];
+  const lastCharCode = lastChar.charCodeAt(0);
+
+  // 한글 완성형 문자 범위 확인 (가-힣)
+  if (lastCharCode >= 0xac00 && lastCharCode <= 0xd7a3) {
+    // 받침 확인: (문자코드 - 0xAC00) % 28
+    const finalConsonantIndex = (lastCharCode - 0xac00) % 28;
+
+    // 받침이 없으면 "가", 있으면 "이"
+    return finalConsonantIndex === 0 ? "가" : "이";
+  }
+
+  // 한글이 아닌 경우 기본값
+  return "이";
+};
+
+/**
+ * 한글 단어에 "은/는" 조사를 붙입니다.
+ * @param word - 조사를 결정할 한글 단어
+ * @returns "은" 또는 "는"
+ */
+export const getTopicParticle = (word: string): string => {
+  if (!word) return "은";
+
+  const lastChar = word[word.length - 1];
+  const lastCharCode = lastChar.charCodeAt(0);
+
+  // 한글 완성형 문자 범위 확인 (가-힣)
+  if (lastCharCode >= 0xac00 && lastCharCode <= 0xd7a3) {
+    // 받침 확인: (문자코드 - 0xAC00) % 28
+    const finalConsonantIndex = (lastCharCode - 0xac00) % 28;
+
+    // 받침이 없으면 "는", 있으면 "은"
+    return finalConsonantIndex === 0 ? "는" : "은";
+  }
+
+  // 한글이 아닌 경우 기본값
+  return "은";
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> [Feat] 내 서재 페이지 API 연동 #45 

## 📝작업 내용

> 메인 페이지인 내 서재 페이지에서 일어나는 API들 전부 연동
- 일부 라우팅 수정
- 일부 컴포넌트 분리
    - 한글 조사 구분함수 분리
- 책 하나에 대한 영상 조회 API 연동
- 책에 대한 인물 조회 API 연동


### 스크린샷 (선택)
<img width="2048" height="701" alt="image" src="https://github.com/user-attachments/assets/3a1d8038-d4c9-42cf-960c-5ce0ffba8092" />

<img width="2048" height="1305" alt="image" src="https://github.com/user-attachments/assets/7c2cabab-0ff9-447b-99a7-67c2a6423429" />

