### PR TITLE
[Feat] 대본 생성 페이지 API 연동

### DIFF
--- a/src/api/characterApi.ts
+++ b/src/api/characterApi.ts
@@ -11,6 +11,34 @@ export interface CharacterApiResponse {
   scenes: unknown[]; // 응답에 포함되어 있음
 }
 
+export interface ScriptScene {
+  sceneId: number;
+  background: string;
+  mood: string;
+  style: string;
+  camera: string;
+  soundtrack: string;
+  characters: {
+    name: string;
+    appearance: string;
+    expression: string;
+    action: string;
+  }[];
+  lines: {
+    speaker: string;
+    line_en: string;
+    line_ko: string;
+  }[];
+  rewriting_prompt: string;
+  rewriting_id: string;
+}
+
+export interface ScriptApiResponse {
+  script_id: string;
+  characterId: number;
+  scenes: ScriptScene[];
+}
+
 // 특정 책의 캐릭터 목록 조회 및 생성 (POST /characters/books/{bookId}/)
 export const getCharactersByBookId = async (
   bookId: number
@@ -23,6 +51,25 @@ export const getCharactersByBookId = async (
     return response.data;
   } catch (error) {
     console.error(`Failed to fetch characters for book ${bookId}:`, error);
+    throw error;
+  }
+};
+
+// 특정 캐릭터의 스크립트 생성 (POST /characters/{characterId}/script/)
+export const createScript = async (
+  characterId: number
+): Promise<ScriptApiResponse> => {
+  try {
+    const response = await axios.post<ScriptApiResponse>(
+      ENDPOINTS.scripts.create(characterId.toString())
+    );
+    console.log("Script API 응답:", response.data);
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Failed to create script for character ${characterId}:`,
+      error
+    );
     throw error;
   }
 };

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -27,7 +27,7 @@ export const ENDPOINTS = {
   },
   scripts: {
     create: (characterId: string) =>
-      API_URL(`/characters/${characterId}/script`), // 인물을 바탕으로 스크립트 생성
+      API_URL(`/characters/${characterId}/script/`), // 인물을 바탕으로 스크립트 생성
   },
   videos: {
     get: API_URL(""), // 저장된 영상 목록 조회

--- a/src/components/ActCharacterCard.tsx
+++ b/src/components/ActCharacterCard.tsx
@@ -15,6 +15,7 @@ type ApiCharacterType = {
 
 // UI에서 사용할 타입 (기존 JSON 형식과 호환)
 type CharacterType = {
+  id?: number; // API ID 추가
   name: string;
   sex: string;
   description: string;
@@ -22,10 +23,12 @@ type CharacterType = {
 
 interface ActCharacterCardProps {
   characters?: ApiCharacterType[]; // API에서 받은 캐릭터 데이터 (optional)
+  onCharacterSelect?: (character: { id?: number; name: string }) => void; // 캐릭터 선택 콜백
 }
 
 const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
   characters: apiCharacters,
+  onCharacterSelect,
 }) => {
   const [characters, setCharacters] = useState<CharacterType[]>([]);
   const [flipped, setFlipped] = useState<boolean[]>([]);
@@ -36,6 +39,7 @@ const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
       // API에서 받은 데이터를 UI 형식으로 변환
       const transformedCharacters: CharacterType[] = apiCharacters.map(
         (char) => ({
+          id: char.id, // API ID 포함
           name: char.characterName,
           sex:
             char.gender === "male"
@@ -84,26 +88,51 @@ const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
     });
   };
 
+  const handleCharacterSelect = (character: CharacterType) => {
+    if (onCharacterSelect) {
+      onCharacterSelect({ id: character.id, name: character.name });
+    }
+  };
+
   return (
     <div className="flex justify-center justify-evenly w-full">
       {characters.map((character, idx) => (
         <div
           key={`${character.name}-${idx}`}
-          className={`flip-card ${flipped[idx] ? "flipped" : ""}`}
-          style={{ width: 300, height: 400, cursor: "pointer" }}
-          onClick={() => handleFlip(idx)}
+          className="relative"
+          style={{ width: 300, height: 400 }}
         >
-          <div className="flip-card-inner">
-            <div className="flip-card-front">
-              <FrontCharacterCard name={character.name} sex={character.sex} />
-            </div>
-            <div className="flip-card-back">
-              <BackCharacterCard
-                name={character.name}
-                description={character.description}
-              />
+          <div
+            className={`flip-card ${flipped[idx] ? "flipped" : ""}`}
+            style={{ width: 300, height: 400, cursor: "pointer" }}
+            onClick={() => handleFlip(idx)}
+          >
+            <div className="flip-card-inner">
+              <div className="flip-card-front">
+                <FrontCharacterCard name={character.name} sex={character.sex} />
+              </div>
+              <div className="flip-card-back">
+                <BackCharacterCard
+                  name={character.name}
+                  description={character.description}
+                />
+              </div>
             </div>
           </div>
+
+          {/* 캐릭터 선택 버튼 */}
+          <button
+            onClick={(e) => {
+              e.stopPropagation(); // 카드 뒤집기 이벤트 방지
+              handleCharacterSelect(character);
+            }}
+            className="absolute bottom-4 left-1/2 transform -translate-x-1/2 
+                       bg-[#DCAC62] hover:bg-[#C89B51] text-white font-semibold 
+                       px-6 py-2 rounded-lg transition-colors duration-200
+                       shadow-md hover:shadow-lg z-10"
+          >
+            선택하기
+          </button>
         </div>
       ))}
       <style>{`

--- a/src/components/ActCharacterCard.tsx
+++ b/src/components/ActCharacterCard.tsx
@@ -23,12 +23,12 @@ type CharacterType = {
 
 interface ActCharacterCardProps {
   characters?: ApiCharacterType[]; // API에서 받은 캐릭터 데이터 (optional)
-  onCharacterSelect?: (character: { id?: number; name: string }) => void; // 캐릭터 선택 콜백
+  onScriptCreate?: (characterId: number, characterName: string) => void; // 대본 생성 콜백
 }
 
 const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
   characters: apiCharacters,
-  onCharacterSelect,
+  onScriptCreate,
 }) => {
   const [characters, setCharacters] = useState<CharacterType[]>([]);
   const [flipped, setFlipped] = useState<boolean[]>([]);
@@ -88,9 +88,9 @@ const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
     });
   };
 
-  const handleCharacterSelect = (character: CharacterType) => {
-    if (onCharacterSelect) {
-      onCharacterSelect({ id: character.id, name: character.name });
+  const handleScriptCreate = (characterId: number, characterName: string) => {
+    if (onScriptCreate) {
+      onScriptCreate(characterId, characterName);
     }
   };
 
@@ -99,40 +99,23 @@ const ActCharacterCard: React.FC<ActCharacterCardProps> = ({
       {characters.map((character, idx) => (
         <div
           key={`${character.name}-${idx}`}
-          className="relative"
-          style={{ width: 300, height: 400 }}
+          className={`flip-card ${flipped[idx] ? "flipped" : ""}`}
+          style={{ width: 300, height: 400, cursor: "pointer" }}
+          onClick={() => handleFlip(idx)}
         >
-          <div
-            className={`flip-card ${flipped[idx] ? "flipped" : ""}`}
-            style={{ width: 300, height: 400, cursor: "pointer" }}
-            onClick={() => handleFlip(idx)}
-          >
-            <div className="flip-card-inner">
-              <div className="flip-card-front">
-                <FrontCharacterCard name={character.name} sex={character.sex} />
-              </div>
-              <div className="flip-card-back">
-                <BackCharacterCard
-                  name={character.name}
-                  description={character.description}
-                />
-              </div>
+          <div className="flip-card-inner">
+            <div className="flip-card-front">
+              <FrontCharacterCard name={character.name} sex={character.sex} />
+            </div>
+            <div className="flip-card-back">
+              <BackCharacterCard
+                name={character.name}
+                description={character.description}
+                characterId={character.id}
+                onScriptCreate={handleScriptCreate}
+              />
             </div>
           </div>
-
-          {/* 캐릭터 선택 버튼 */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation(); // 카드 뒤집기 이벤트 방지
-              handleCharacterSelect(character);
-            }}
-            className="absolute bottom-4 left-1/2 transform -translate-x-1/2 
-                       bg-[#DCAC62] hover:bg-[#C89B51] text-white font-semibold 
-                       px-6 py-2 rounded-lg transition-colors duration-200
-                       shadow-md hover:shadow-lg z-10"
-          >
-            선택하기
-          </button>
         </div>
       ))}
       <style>{`

--- a/src/components/BackCharacterCard.tsx
+++ b/src/components/BackCharacterCard.tsx
@@ -1,17 +1,25 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import I_Script from "../assets/Icons/Script.svg";
 
 interface BackProps {
   name: string;
   description: string;
+  characterId?: number;
+  onScriptCreate: (characterId: number, characterName: string) => void;
 }
 
-const BackCharacterCard: React.FC<BackProps> = ({ name, description }) => {
-  const navigate = useNavigate();
+const BackCharacterCard: React.FC<BackProps> = ({
+  name,
+  description,
+  characterId,
+  onScriptCreate,
+}) => {
+  const handleScriptCreate = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 카드 뒤집기 이벤트 방지
 
-  const handleScriptCreate = () => {
-    navigate("/script");
+    if (characterId && onScriptCreate) {
+      onScriptCreate(characterId, name);
+    }
   };
 
   return (
@@ -33,8 +41,9 @@ const BackCharacterCard: React.FC<BackProps> = ({ name, description }) => {
       <button
         className="w-[190px] h-[42px] flex mt-8 mb-4 rounded-[8px] bg-[#FFF5E3] text-black text-[20px] border-2 border-gray font-bold shadow-[0_4px_12px_0_rgba(0,0,0,0.09)] hover:bg-[#E9E3DC] transition"
         onClick={handleScriptCreate}
+        disabled={!characterId}
       >
-        <div className="flex mt-1 gap-2">
+        <div className="flex mt-1 gap-2 items-center">
           <img
             src={I_Script}
             alt="대본 생성"

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -7,6 +7,7 @@ interface ConfirmModalProps {
   visible: boolean;
   isLoading?: boolean;
   confirmText?: string;
+  message?: string; // 안내 문구
 }
 
 const EXIT_ANIMATION_TIME = 220;
@@ -18,6 +19,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   visible,
   isLoading = false,
   confirmText = "확인",
+  message,
 }) => {
   const [show, setShow] = useState(false);
   const [animState, setAnimState] = useState<
@@ -64,7 +66,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
         `}
       >
         <div className="text-xl font-bold mb-4">
-          선택한 인물로 진행하시겠습니까?
+          {message || "선택한 인물로 진행하시겠습니까?"}
         </div>
         <div className="mb-6 text-[48px] text-[#5a4630] font-medium font-black">
           {name}

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -5,6 +5,8 @@ interface ConfirmModalProps {
   onConfirm: () => void;
   onCancel: () => void;
   visible: boolean;
+  isLoading?: boolean;
+  confirmText?: string;
 }
 
 const EXIT_ANIMATION_TIME = 220;
@@ -14,6 +16,8 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
   onConfirm,
   onCancel,
   visible,
+  isLoading = false,
+  confirmText = "확인",
 }) => {
   const [show, setShow] = useState(false);
   const [animState, setAnimState] = useState<
@@ -67,16 +71,21 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
         </div>
         <div className="flex gap-4">
           <button
-            className="px-6 py-2 rounded bg-gray-200 text-[#000000] font-bold hover:bg-gray-300 transition"
+            className="px-6 py-2 rounded bg-gray-200 text-[#000000] font-bold hover:bg-gray-300 transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
             style={{ boxShadow: "inset 0 0 0 4px #FFFFFF" }}
             onClick={onConfirm}
+            disabled={isLoading}
           >
-            확인
+            {isLoading && (
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-[#000000]"></div>
+            )}
+            {isLoading ? "처리중..." : confirmText}
           </button>
           <button
-            className="px-6 py-2 rounded bg-gray-200 text-[#000000] font-bold hover:bg-gray-300 transition"
+            className="px-6 py-2 rounded bg-gray-200 text-[#000000] font-bold hover:bg-gray-300 transition disabled:opacity-50 disabled:cursor-not-allowed"
             style={{ boxShadow: "inset 0 0 0 4px #FFFFFF" }}
             onClick={onCancel}
+            disabled={isLoading}
           >
             취소
           </button>

--- a/src/components/Script.tsx
+++ b/src/components/Script.tsx
@@ -8,12 +8,11 @@ export interface ScriptProps {
 
 const Script: React.FC<ScriptProps> = ({ sceneTitle, children }) => {
   return (
-    <div className="relative bg-[#F8F9FA] rounded-[30px] w-[1102px] h-[170px] p-6">
+    <div className="flex flex-col bg-[#F8F9FA] rounded-[30px] w-[1102px] h-[170px] p-6">
       {/* Scene Badge */}
       {sceneTitle && (
         <span
           className="
-            absolute top-3 left-5
             inline-flex items-center justify-center   /* 인라인 박스 + 중앙 정렬 */
             w-[109px] h-[28px]                       /* Figma에 맞춘 크기 */
             bg-[#0008FF] bg-opacity-[19%]            /* 배경색 #2900BC, 투명도 19% */

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -66,15 +66,18 @@ const CharacterSelectPage: React.FC = () => {
     characterName: string
   ) => {
     // 먼저 캐시된 스크립트가 있는지 확인
-    const cachedScript = getScriptCache(characterId);
+    const cachedScripts = getScriptCache(characterId);
 
-    if (cachedScript) {
+    // 원본 또는 재생성된 대본이 있으면 바로 이동 (원본 우선)
+    if (cachedScripts.original || cachedScripts.regenerated) {
+      const scriptData = cachedScripts.original || cachedScripts.regenerated;
       console.log("캐시된 스크립트 사용:", characterName);
-      // 캐시된 스크립트가 있으면 바로 이동
+
       navigate("/script", {
         state: {
-          scriptData: cachedScript,
+          scriptData,
           characterName,
+          characterId,
         },
       });
       return;
@@ -88,14 +91,15 @@ const CharacterSelectPage: React.FC = () => {
       // 스크립트 생성 API 호출
       const scriptData = await createScript(characterId);
 
-      // 새로 생성된 스크립트를 캐시에 저장
-      setScriptCache(characterId, characterName, scriptData);
+      // 새로 생성된 스크립트를 캐시에 저장 (원본으로)
+      setScriptCache(characterId, characterName, scriptData, false);
 
       // ScriptPage로 네비게이션하면서 스크립트 데이터 전달
       navigate("/script", {
         state: {
           scriptData,
           characterName,
+          characterId,
         },
       });
     } catch (error) {

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -9,6 +9,7 @@ import MoreCharacters from "../components/MoreCharacters";
 import Down_flag from "../assets/Icons/Down_flag.svg";
 import ConfirmModal from "../components/ConfirmModal";
 import { createScript } from "../api/characterApi";
+import { useAppStore } from "../stores/appStore";
 
 const CharacterSelectPage: React.FC = () => {
   const navigate = useNavigate();
@@ -17,82 +18,109 @@ const CharacterSelectPage: React.FC = () => {
   const [modalName, setModalName] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
-  const [selectedCharacter, setSelectedCharacter] = useState<{
-    id?: number;
-    name: string;
-  } | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
 
-  // MyLibraryPage에서 전달받은 캐릭터 데이터
-  const { characters, bookTitle } = location.state || {};
+  // 대본 생성 로딩 상태
+  const [isScriptLoading, setIsScriptLoading] = useState(false);
+  const [scriptCharacterName, setScriptCharacterName] = useState<string>("");
+
+  // Zustand store 사용
+  const {
+    currentBookSession,
+    isBookSessionValid,
+    getScriptCache,
+    setScriptCache,
+  } = useAppStore();
+
+  // MyLibraryPage에서 전달받은 캐릭터 데이터 또는 store에서 가져온 데이터
+  const locationState = location.state || {};
+  const { characters: locationCharacters, bookTitle: locationBookTitle } =
+    locationState;
+
+  // Store의 데이터가 유효하면 사용, 아니면 location.state 사용
+  const characters =
+    isBookSessionValid() && currentBookSession?.characters
+      ? currentBookSession.characters
+      : locationCharacters;
+  const bookTitle =
+    isBookSessionValid() && currentBookSession?.bookTitle
+      ? currentBookSession.bookTitle
+      : locationBookTitle;
 
   // 캐릭터 데이터가 없으면 MyLibrary로 리다이렉트
   useEffect(() => {
     if (!characters || !bookTitle) {
+      console.warn("캐릭터 또는 책 정보가 없습니다:", {
+        characters: !!characters,
+        bookTitle: !!bookTitle,
+      });
       alert("잘못된 접근입니다. 책을 선택해주세요.");
       navigate("/");
     }
   }, [characters, bookTitle, navigate]);
 
-  // ActCharacterCard에서 캐릭터 선택 시 호출
-  const handleCharacterSelect = async (character: {
-    id?: number;
-    name: string;
-  }) => {
-    if (!character.id) {
-      alert("캐릭터 정보가 없습니다.");
+  // 대본 생성 시작 핸들러
+  const handleScriptCreate = async (
+    characterId: number,
+    characterName: string
+  ) => {
+    // 먼저 캐시된 스크립트가 있는지 확인
+    const cachedScript = getScriptCache(characterId);
+
+    if (cachedScript) {
+      console.log("캐시된 스크립트 사용:", characterName);
+      // 캐시된 스크립트가 있으면 바로 이동
+      navigate("/script", {
+        state: {
+          scriptData: cachedScript,
+          characterName,
+        },
+      });
       return;
     }
 
-    setSelectedCharacter(character);
-    setModalName(character.name);
-    setModalVisible(true);
-  };
+    // 캐시된 스크립트가 없으면 API 호출
+    setIsScriptLoading(true);
+    setScriptCharacterName(characterName);
 
-  const handleConfirm = async () => {
-    if (!selectedCharacter?.id) {
-      alert("선택된 캐릭터가 없습니다.");
-      return;
-    }
-
-    setIsLoading(true);
     try {
       // 스크립트 생성 API 호출
-      const scriptData = await createScript(selectedCharacter.id);
+      const scriptData = await createScript(characterId);
 
-      setModalVisible(false);
-      setTimeout(() => {
-        setModalName(null);
-        setSelectedCharacter(null);
-        // ScriptPage로 네비게이션하면서 스크립트 데이터 전달
-        navigate("/script", {
-          state: {
-            scriptData,
-            characterName: selectedCharacter.name,
-          },
-        });
-      }, 220);
+      // 새로 생성된 스크립트를 캐시에 저장
+      setScriptCache(characterId, characterName, scriptData);
+
+      // ScriptPage로 네비게이션하면서 스크립트 데이터 전달
+      navigate("/script", {
+        state: {
+          scriptData,
+          characterName,
+        },
+      });
     } catch (error) {
       console.error("스크립트 생성 실패:", error);
       alert("스크립트 생성에 실패했습니다. 다시 시도해주세요.");
     } finally {
-      setIsLoading(false);
+      setIsScriptLoading(false);
+      setScriptCharacterName("");
     }
   };
 
+  const handleConfirm = () => {
+    setModalVisible(false); // 먼저 숨기기
+    setTimeout(() => {
+      setModalName(null); // 애니메이션 후 완전 제거
+      navigate("/script");
+    }, 220); // ConfirmModal.tsx의 duration과 맞추세요
+  };
+
   const handleNameClick = (name: string) => {
-    // MoreCharacters에서 클릭 시 ID 없이 처리 (기존 로직 유지)
     setModalName(name);
-    setModalVisible(true);
-    setSelectedCharacter({ name }); // ID 없이 설정
+    setModalVisible(true); // 모달 등장
   };
 
   const handleCancel = () => {
     setModalVisible(false);
-    setTimeout(() => {
-      setModalName(null);
-      setSelectedCharacter(null);
-    }, 220);
+    setTimeout(() => setModalName(null), 220);
   };
 
   useEffect(() => {
@@ -105,6 +133,32 @@ const CharacterSelectPage: React.FC = () => {
 
   return (
     <div className="min-h-screen bg-[#F8F3ED]">
+      {/* 대본 생성 로딩 모달 */}
+      {isScriptLoading && (
+        <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-8 flex flex-col items-center max-w-md">
+            <div className="w-24 h-24 mb-4">
+              {/* 로딩 애니메이션 - 회전하는 원 */}
+              <div className="animate-spin rounded-full h-24 w-24 border-b-2 border-[#DCAC62]"></div>
+            </div>
+            <p className="text-lg font-semibold text-gray-700 text-center mb-3">
+              <span className="text-[#DCAC62]">{scriptCharacterName}</span>의{" "}
+              <br />
+              브이로그 대본을 생성하고 있어요!
+            </p>
+            <div className="text-sm text-gray-500 text-center space-y-1">
+              <p>🤖 AI가 캐릭터의 성격을 분석 중입니다</p>
+              <p>✍️ 매력적인 브이로그 대본을 작성 중입니다</p>
+              <p>🎬 영상에 맞는 스크립트를 준비 중입니다</p>
+              <p className="text-xs text-gray-400 mt-2">
+                잠시만 기다려주세요
+                <br />곧 완성됩니다!
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
       <Header
         showNavigation={true}
         navigationComponent={<Stepper currentStep={1} />}
@@ -133,7 +187,7 @@ const CharacterSelectPage: React.FC = () => {
           <div className="py-10">
             <ActCharacterCard
               characters={characters}
-              onCharacterSelect={handleCharacterSelect}
+              onScriptCreate={handleScriptCreate}
             />
           </div>
 
@@ -178,23 +232,9 @@ const CharacterSelectPage: React.FC = () => {
         {modalName && (
           <ConfirmModal
             name={modalName}
-            onConfirm={
-              selectedCharacter?.id
-                ? handleConfirm
-                : () => {
-                    // ID가 없는 경우 (MoreCharacters에서 선택) 기존 로직
-                    setModalVisible(false);
-                    setTimeout(() => {
-                      setModalName(null);
-                      setSelectedCharacter(null);
-                      navigate("/script");
-                    }, 220);
-                  }
-            }
+            onConfirm={handleConfirm}
             onCancel={handleCancel}
             visible={modalVisible}
-            isLoading={isLoading}
-            confirmText={selectedCharacter?.id ? "대본작성하기" : "선택하기"}
           />
         )}
       </div>

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -29,6 +29,8 @@ const CharacterSelectPage: React.FC = () => {
     isBookSessionValid,
     getScriptCache,
     setScriptCache,
+    scriptCache,
+    clearAllScripts,
   } = useAppStore();
 
   // MyLibraryPage에서 전달받은 캐릭터 데이터 또는 store에서 가져온 데이터
@@ -131,6 +133,31 @@ const CharacterSelectPage: React.FC = () => {
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
+  // 내 서재로 돌아가기 안내 모달 상태
+  const [showGoHomeModal, setShowGoHomeModal] = useState(false);
+
+  // 내 서재로 돌아가기 버튼 클릭 핸들러
+  const handleGoHomeClick = () => {
+    // scriptCache에 값이 하나라도 있으면 모달 띄움
+    if (scriptCache && Object.keys(scriptCache).length > 0) {
+      setShowGoHomeModal(true);
+    } else {
+      navigate("/");
+    }
+  };
+
+  // 내 서재로 돌아가기 모달에서 확인
+  const handleGoHomeConfirm = () => {
+    clearAllScripts();
+    setShowGoHomeModal(false);
+    navigate("/");
+  };
+
+  // 내 서재로 돌아가기 모달에서 취소
+  const handleGoHomeCancel = () => {
+    setShowGoHomeModal(false);
+  };
+
   return (
     <div className="min-h-screen bg-[#F8F3ED]">
       {/* 대본 생성 로딩 모달 */}
@@ -215,7 +242,7 @@ const CharacterSelectPage: React.FC = () => {
           <CommonButton
             icon={<img src={BackIcon} alt="뒤로가기" className="mr-2" />}
             className="w-[280px] h-[60px] mb-11 mt-10"
-            onClick={() => navigate("/")}
+            onClick={handleGoHomeClick}
           >
             <span className="text-[20px]">내 서재로 돌아가기</span>
           </CommonButton>
@@ -235,6 +262,18 @@ const CharacterSelectPage: React.FC = () => {
             onConfirm={handleConfirm}
             onCancel={handleCancel}
             visible={modalVisible}
+          />
+        )}
+        {showGoHomeModal && (
+          <ConfirmModal
+            name={""}
+            message={
+              "생성한 대본이 초기화됩니다. 정말 내 서재로 돌아가시겠습니까?"
+            }
+            onConfirm={handleGoHomeConfirm}
+            onCancel={handleGoHomeCancel}
+            visible={showGoHomeModal}
+            confirmText="네, 돌아갈래요"
           />
         )}
       </div>

--- a/src/pages/CharacterSelectPage.tsx
+++ b/src/pages/CharacterSelectPage.tsx
@@ -8,6 +8,7 @@ import BackIcon from "../assets/Icons/BackIcon.svg";
 import MoreCharacters from "../components/MoreCharacters";
 import Down_flag from "../assets/Icons/Down_flag.svg";
 import ConfirmModal from "../components/ConfirmModal";
+import { createScript } from "../api/characterApi";
 
 const CharacterSelectPage: React.FC = () => {
   const navigate = useNavigate();
@@ -16,6 +17,11 @@ const CharacterSelectPage: React.FC = () => {
   const [modalName, setModalName] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const [selectedCharacter, setSelectedCharacter] = useState<{
+    id?: number;
+    name: string;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   // MyLibraryPage에서 전달받은 캐릭터 데이터
   const { characters, bookTitle } = location.state || {};
@@ -28,22 +34,65 @@ const CharacterSelectPage: React.FC = () => {
     }
   }, [characters, bookTitle, navigate]);
 
-  const handleConfirm = () => {
-    setModalVisible(false); // 먼저 숨기기
-    setTimeout(() => {
-      setModalName(null); // 애니메이션 후 완전 제거
-      navigate("/script");
-    }, 220); // ConfirmModal.tsx의 duration과 맞추세요
+  // ActCharacterCard에서 캐릭터 선택 시 호출
+  const handleCharacterSelect = async (character: {
+    id?: number;
+    name: string;
+  }) => {
+    if (!character.id) {
+      alert("캐릭터 정보가 없습니다.");
+      return;
+    }
+
+    setSelectedCharacter(character);
+    setModalName(character.name);
+    setModalVisible(true);
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedCharacter?.id) {
+      alert("선택된 캐릭터가 없습니다.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      // 스크립트 생성 API 호출
+      const scriptData = await createScript(selectedCharacter.id);
+
+      setModalVisible(false);
+      setTimeout(() => {
+        setModalName(null);
+        setSelectedCharacter(null);
+        // ScriptPage로 네비게이션하면서 스크립트 데이터 전달
+        navigate("/script", {
+          state: {
+            scriptData,
+            characterName: selectedCharacter.name,
+          },
+        });
+      }, 220);
+    } catch (error) {
+      console.error("스크립트 생성 실패:", error);
+      alert("스크립트 생성에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleNameClick = (name: string) => {
+    // MoreCharacters에서 클릭 시 ID 없이 처리 (기존 로직 유지)
     setModalName(name);
-    setModalVisible(true); // 모달 등장
+    setModalVisible(true);
+    setSelectedCharacter({ name }); // ID 없이 설정
   };
 
   const handleCancel = () => {
     setModalVisible(false);
-    setTimeout(() => setModalName(null), 220);
+    setTimeout(() => {
+      setModalName(null);
+      setSelectedCharacter(null);
+    }, 220);
   };
 
   useEffect(() => {
@@ -82,7 +131,10 @@ const CharacterSelectPage: React.FC = () => {
         >
           {/* 캐릭터 카드 리스트 */}
           <div className="py-10">
-            <ActCharacterCard characters={characters} />
+            <ActCharacterCard
+              characters={characters}
+              onCharacterSelect={handleCharacterSelect}
+            />
           </div>
 
           {/* 인물 더보기 + 안내문구 */}
@@ -126,9 +178,23 @@ const CharacterSelectPage: React.FC = () => {
         {modalName && (
           <ConfirmModal
             name={modalName}
-            onConfirm={handleConfirm}
+            onConfirm={
+              selectedCharacter?.id
+                ? handleConfirm
+                : () => {
+                    // ID가 없는 경우 (MoreCharacters에서 선택) 기존 로직
+                    setModalVisible(false);
+                    setTimeout(() => {
+                      setModalName(null);
+                      setSelectedCharacter(null);
+                      navigate("/script");
+                    }, 220);
+                  }
+            }
             onCancel={handleCancel}
             visible={modalVisible}
+            isLoading={isLoading}
+            confirmText={selectedCharacter?.id ? "대본작성하기" : "선택하기"}
           />
         )}
       </div>

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/bookApi";
 import { getCharactersByBookId } from "../api/characterApi";
 import type { BookApiResponse, VideoApiResponse } from "../api/bookApi";
+import { useAppStore } from "../stores/appStore";
 
 // utils (한글 조사 구분 함수)
 import { getKoreanParticle } from "../utils/koreanUtils";
@@ -38,12 +39,21 @@ const MyLibraryPage: React.FC = () => {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
 
+  // Zustand store 사용
+  const { setBookSession, clearAllScripts } = useAppStore();
+
   // 인증되지 않은 사용자 리다이렉트
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
       navigate("/auth");
     }
   }, [authLoading, isAuthenticated, navigate]);
+
+  // 메인 페이지 진입 시 스크립트 캐시 정리 (선택적)
+  useEffect(() => {
+    // 메인 페이지로 돌아왔을 때 모든 스크립트 캐시 정리
+    clearAllScripts();
+  }, [clearAllScripts]);
 
   const [bookFilter, setBookFilter] = useState<"service" | "uploaded">(
     "service"
@@ -163,10 +173,23 @@ const MyLibraryPage: React.FC = () => {
       // 선택된 책의 캐릭터 목록 API 호출
       const charactersData = await getCharactersByBookId(selectedBook.id);
 
+      // 캐릭터 정보에서 scenes를 제외한 최소 정보만 저장
+      const minimalCharacters = charactersData.map((c) => ({
+        id: c.id,
+        characterName: c.characterName,
+        isMain: c.isMain,
+        age: c.age,
+        gender: c.gender,
+        characterDescription: c.characterDescription,
+      }));
+
+      // Zustand store에 책 세션 정보 저장
+      setBookSession(selectedBook.id, selectedBook.title, minimalCharacters);
+
       // API 응답 완료 후 캐릭터 데이터와 함께 페이지 이동
       navigate("/char", {
         state: {
-          characters: charactersData,
+          characters: minimalCharacters,
           bookTitle: selectedBook.title,
           bookId: selectedBook.id,
         },

--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -1,5 +1,6 @@
 // src/pages/ScriptPage.tsx
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import Header from "../components/Header";
 import Stepper from "../components/Stepper";
 import Script from "../components/Script"; // (장면 하나짜리 박스 컴포넌트)
@@ -8,13 +9,27 @@ import FrontCharacterCard from "../components/FrontCharacterCard";
 import CommonButton from "../components/CommonButton";
 import BackIcon from "../assets/Icons/BackIcon.svg";
 import VideoIcon from "../assets/Icons/VideoIcon.svg"; // 영상 생성 아이콘
-
+import { createScript, type ScriptApiResponse } from "../api/characterApi";
 
 const ScriptPage: React.FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [isRegenerating, setIsRegenerating] = useState(false);
 
-  const [selectedName, setSelectedName] = useState("홍선군")
-  const [selectedSex, setSelectedSex] = useState("남성")
-  const [exampleScripts, setExampleScripts] = useState<string[]>([
+  // CharacterSelectPage에서 전달받은 데이터
+  const { scriptData, characterName } =
+    (location.state as {
+      scriptData?: ScriptApiResponse;
+      characterName?: string;
+    }) || {};
+
+  const [currentScriptData, setCurrentScriptData] =
+    useState<ScriptApiResponse | null>(scriptData || null);
+  const selectedName = characterName || "홍선군";
+  const selectedSex = "남성"; // 기본값, 추후 캐릭터 데이터에서 가져올 수 있음
+
+  // 하드코딩된 예시 대본 (fallback용)
+  const fallbackScripts = [
     `
     (나직하지만 힘 있는 목소리로)
     …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
@@ -29,32 +44,55 @@ const ScriptPage: React.FC = () => {
     (나직하지만 힘 있는 목소리로)
     …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
     허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
+  ];
 
-    `
-    (나직하지만 힘 있는 목소리로)
-    …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
-    허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
+  // 스크립트 데이터가 없으면 캐릭터 선택 페이지로 리다이렉트
+  useEffect(() => {
+    if (!currentScriptData) {
+      console.warn(
+        "스크립트 데이터가 없습니다. 캐릭터 선택 페이지로 이동합니다."
+      );
+      // 개발 중에는 fallback 데이터 사용, 실제로는 아래 주석을 해제
+      // navigate("/character-select");
+    }
+  }, [currentScriptData, navigate]);
 
-    `
-    (나직하지만 힘 있는 목소리로)
-    …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
-    허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
+  // API 응답에서 스크립트 텍스트 추출
+  const getScriptsFromData = () => {
+    if (!currentScriptData?.scenes) {
+      return fallbackScripts;
+    }
 
-    `
-    (나직하지만 힘 있는 목소리로)
-    …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
-    허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
+    return currentScriptData.scenes.map((scene) => {
+      const lines = scene.lines
+        .map((line) => `${line.speaker}: ${line.line_ko}`)
+        .join("\n");
+      const background = scene.background ? `배경: ${scene.background}` : "";
+      const mood = scene.mood ? `분위기: ${scene.mood}` : "";
 
-    `
-    (나직하지만 힘 있는 목소리로)
-    …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
-    허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
-  ]);
-    
-
-const handleRegenerate = () => {
-    console.log("대본 재생성!");
+      return `${background ? background + "\n" : ""}${mood ? mood + "\n" : ""}${lines}`;
+    });
   };
+
+  const handleRegenerate = async () => {
+    if (!currentScriptData?.characterId) {
+      console.error("캐릭터 ID가 없어 재생성할 수 없습니다.");
+      return;
+    }
+
+    setIsRegenerating(true);
+    try {
+      const newScriptData = await createScript(currentScriptData.characterId);
+      setCurrentScriptData(newScriptData);
+    } catch (error) {
+      console.error("스크립트 재생성 실패:", error);
+      alert("스크립트 재생성에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsRegenerating(false);
+    }
+  };
+
+  const scripts = getScriptsFromData();
 
   return (
     <div className="min-h-screen bg-[#F8F3ED]">
@@ -89,15 +127,18 @@ const handleRegenerate = () => {
         <div className="flex justify-center ml-[37.26px]">
           <div className="relative">
             {/* 실제 컨테이너 (패딩 포함) */}
-            <div className="
+            <div
+              className="
                 w-[1206px] h-[661px]
                 bg-white rounded-[30px]
                 shadow-[0_4px_8.7px_rgba(0,0,0,0.25)]
                 p-[23.78px_20px_57.78px_41px]
                 box-border
-              ">
+              "
+            >
               {/* 스크롤 래퍼 */}
-              <div className={`
+              <div
+                className={`
                 w-full h-full
                 overflow-y-scroll overflow-x-hidden
 
@@ -119,10 +160,14 @@ const handleRegenerate = () => {
                 [&::-webkit-scrollbar-thumb]:border-solid
                 [&::-webkit-scrollbar-thumb]:border-transparent
                 [&::-webkit-scrollbar-thumb]:bg-clip-content
-              `}>
+              `}
+              >
                 <div className="space-y-[34px] w-[1102px]">
-                  {exampleScripts.map((text, idx) => (
-                    <Script key={idx} sceneTitle={`Scene #${idx + 1}`}>
+                  {scripts.map((text, idx) => (
+                    <Script
+                      key={`${currentScriptData?.script_id || "fallback"}-${idx}`}
+                      sceneTitle={`Scene #${idx + 1}`}
+                    >
                       {text}
                     </Script>
                   ))}
@@ -133,6 +178,7 @@ const handleRegenerate = () => {
             {/* 절대 위치 재생성 버튼 */}
             <button
               onClick={handleRegenerate}
+              disabled={isRegenerating}
               className="
                 absolute
                 bottom-[calc(100%+22px)]    /* 컨테이너 테두리 기준 22px 위 */
@@ -140,17 +186,28 @@ const handleRegenerate = () => {
                 flex items-center gap-[6px] h-[27px]
                 font-nanumGothic font-semibold text-[20px] text-black
                 cursor-pointer hover:underline transition
+                disabled:opacity-50 disabled:cursor-not-allowed
               "
             >
-              <img src={Regenerating} alt="재생성" className="w-[24px] h-[24px]" />
-              재생성
+              <img
+                src={Regenerating}
+                alt="재생성"
+                className={`w-[24px] h-[24px] ${isRegenerating ? "animate-spin" : ""}`}
+              />
+              {isRegenerating ? "생성중..." : "재생성"}
             </button>
 
             {/* 4) 하단 버튼들 */}
-             <CommonButton
-               icon={<img src={BackIcon} alt="뒤로가기" className="w-[20px] h-[20px]" />}
-               onClick={() => console.log("인물선택으로 돌아가기")}
-               className="
+            <CommonButton
+              icon={
+                <img
+                  src={BackIcon}
+                  alt="뒤로가기"
+                  className="w-[20px] h-[20px]"
+                />
+              }
+              onClick={() => navigate("/character-select")}
+              className="
                 absolute
                 top-[calc(100%+19px)]                 /* 컨테이너 아래에서 19px 아래 */
                 right-[calc(100%+39px)]       /* 컨테이너 왼쪽에서 39px 왼쪽 */
@@ -158,14 +215,20 @@ const handleRegenerate = () => {
                 flex items-center justify-center gap-[21px]
                 font-nanumGothic font-semibold text-[20px] text-black
               "
-             >
+            >
               인물선택으로 돌아가기
-             </CommonButton>
+            </CommonButton>
 
-             <CommonButton
-               icon={<img src={VideoIcon} alt="영상 생성" className="w-[20px] h-[20px]" />}
-               onClick={() => console.log("영상 생성")}
-               className="
+            <CommonButton
+              icon={
+                <img
+                  src={VideoIcon}
+                  alt="영상 생성"
+                  className="w-[20px] h-[20px]"
+                />
+              }
+              onClick={() => console.log("영상 생성")}
+              className="
                 absolute
                 top-[calc(100%+19px)]                /* 컨테이너 아래에서 19px 아래 */
                 left-[calc(100%+39px)]        /* 컨테이너 오른쪽에서 39px 오른쪽 */
@@ -173,9 +236,9 @@ const handleRegenerate = () => {
                 flex items-center justify-center gap-[26px]
                 font-nanumGothic font-semibold text-[20px] text-black
               "
-             >
-             영상생성
-             </CommonButton>
+            >
+              영상생성
+            </CommonButton>
           </div>
         </div>
       </div>

--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -11,25 +11,48 @@ import BackIcon from "../assets/Icons/BackIcon.svg";
 import VideoIcon from "../assets/Icons/VideoIcon.svg"; // 영상 생성 아이콘
 import { createScript, type ScriptApiResponse } from "../api/characterApi";
 import { useAppStore } from "../stores/appStore";
+import ConfirmModal from "../components/ConfirmModal";
 
 const ScriptPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const [isRegenerating, setIsRegenerating] = useState(false);
 
   // Zustand store 사용
-  const { currentBookSession, isBookSessionValid, setScriptCache } =
-    useAppStore();
+  const {
+    currentBookSession,
+    isBookSessionValid,
+    setScriptCache,
+    getScriptCache,
+  } = useAppStore();
 
   // CharacterSelectPage에서 전달받은 데이터
-  const { scriptData, characterName } =
+  const { scriptData, characterName, characterId } =
     (location.state as {
       scriptData?: ScriptApiResponse;
       characterName?: string;
+      characterId?: number;
     }) || {};
 
-  const [currentScriptData, setCurrentScriptData] =
+  // 최초 대본(A), 재생성 대본(B) 상태 분리
+  const [originalScript, setOriginalScript] =
     useState<ScriptApiResponse | null>(scriptData || null);
+  const [regeneratedScript, setRegeneratedScript] =
+    useState<ScriptApiResponse | null>(null);
+
+  // 현재 보여주는 대본이 original인지 regenerated인지
+  const [viewMode, setViewMode] = useState<"original" | "regenerated">(
+    "original"
+  );
+  // 재생성 안내 모달
+  const [showRegenerateModal, setShowRegenerateModal] = useState(false);
+  // 재생성 중 상태
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  // 재생성 버튼 비활성화(한 번만 가능)
+  const [regenerateUsed, setRegenerateUsed] = useState(false);
+
+  // 툴팁 상태
+  const [showTooltip, setShowTooltip] = useState(false);
+
   const selectedName = characterName || "홍선군";
   const selectedSex = "남성"; // 기본값, 추후 캐릭터 데이터에서 가져올 수 있음
 
@@ -39,75 +62,98 @@ const ScriptPage: React.FC = () => {
     (나직하지만 힘 있는 목소리로)
     …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
     허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
-
     `
     (나직하지만 힘 있는 목소리로)
     …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
     허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
-
     `
     (나직하지만 힘 있는 목소리로)
     …내관이 고하더군. 이 하전, 그 아이에게 사약을 내렸다고. 어명이라 했지.
     허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
   ];
 
-  // 스크립트 데이터를 store에 저장 (처음 마운트될 때)
+  // 캐시에서 스크립트 로드 및 초기 설정
   useEffect(() => {
-    if (currentScriptData && characterName) {
-      // 스크립트 데이터를 캐시에 저장
-      setScriptCache(
-        currentScriptData.characterId,
-        characterName,
-        currentScriptData
-      );
+    const actualCharacterId = characterId || originalScript?.characterId;
+
+    if (actualCharacterId) {
+      const cachedScripts = getScriptCache(actualCharacterId);
+
+      // 캐시에서 스크립트 복원
+      if (cachedScripts.original && !originalScript) {
+        setOriginalScript(cachedScripts.original);
+      }
+      if (cachedScripts.regenerated) {
+        setRegeneratedScript(cachedScripts.regenerated);
+        setRegenerateUsed(true);
+        setViewMode("regenerated"); // 재생성된 대본이 있으면 그것을 먼저 보여줌
+      }
+
+      // 새로운 원본 스크립트가 있으면 캐시에 저장
+      if (originalScript && characterName) {
+        setScriptCache(actualCharacterId, characterName, originalScript, false);
+      }
     }
-  }, [currentScriptData, characterName, setScriptCache]);
+  }, [
+    originalScript,
+    characterName,
+    characterId,
+    getScriptCache,
+    setScriptCache,
+  ]);
 
   // 스크립트 데이터가 없으면 적절한 페이지로 리다이렉트
   useEffect(() => {
-    if (!currentScriptData) {
+    if (!originalScript) {
       console.warn("스크립트 데이터가 없습니다.");
-
-      // store에 유효한 책 세션이 있으면 캐릭터 선택 페이지로, 없으면 메인으로
       if (isBookSessionValid()) {
         navigate("/char");
       } else {
         navigate("/");
       }
     }
-  }, [currentScriptData, navigate, isBookSessionValid]);
+  }, [originalScript, navigate, isBookSessionValid]);
+
+  // 현재 보여줄 대본 데이터
+  const currentScriptData =
+    viewMode === "original" ? originalScript : regeneratedScript;
 
   // API 응답에서 스크립트 텍스트 추출
   const getScriptsFromData = () => {
     if (!currentScriptData?.scenes) {
       return fallbackScripts;
     }
-
     return currentScriptData.scenes.map((scene) => {
       const lines = scene.lines
         .map((line) => `${line.speaker}: ${line.line_ko}`)
         .join("\n");
       const background = scene.background ? `배경: ${scene.background}` : "";
       const mood = scene.mood ? `분위기: ${scene.mood}` : "";
-
       return `${background ? background + "\n" : ""}${mood ? mood + "\n" : ""}${lines}`;
     });
   };
 
-  const handleRegenerate = async () => {
-    if (!currentScriptData?.characterId) {
-      console.error("캐릭터 ID가 없어 재생성할 수 없습니다.");
-      return;
-    }
+  // 재생성 버튼 클릭 시 안내 모달
+  const handleRegenerateClick = () => {
+    setShowRegenerateModal(true);
+  };
+
+  // 안내 모달에서 확인 시 재생성 진행
+  const handleRegenerateConfirm = async () => {
+    setShowRegenerateModal(false);
+    const actualCharacterId = characterId || originalScript?.characterId;
+    if (!actualCharacterId) return;
 
     setIsRegenerating(true);
     try {
-      const newScriptData = await createScript(currentScriptData.characterId);
-      setCurrentScriptData(newScriptData);
+      const newScriptData = await createScript(actualCharacterId);
+      setRegeneratedScript(newScriptData);
+      setViewMode("regenerated");
+      setRegenerateUsed(true);
 
-      // 새로 생성된 스크립트를 캐시에 업데이트
+      // 재생성된 대본을 캐시에 저장
       if (characterName) {
-        setScriptCache(newScriptData.characterId, characterName, newScriptData);
+        setScriptCache(actualCharacterId, characterName, newScriptData, true);
       }
     } catch (error) {
       console.error("스크립트 재생성 실패:", error);
@@ -117,9 +163,34 @@ const ScriptPage: React.FC = () => {
     }
   };
 
+  // 안내 모달에서 취소
+  const handleRegenerateCancel = () => {
+    setShowRegenerateModal(false);
+  };
+
+  // 기존/재생성 대본 전환 버튼
+  const renderSwitchButtons = () => {
+    if (!regeneratedScript) return null;
+    return (
+      <div className="flex gap-2 mb-2 justify-end">
+        <button
+          className={`px-4 py-1 rounded font-semibold border ${viewMode === "original" ? "bg-[#DCAC62] text-white" : "bg-white text-[#DCAC62] border-[#DCAC62]"}`}
+          onClick={() => setViewMode("original")}
+        >
+          기존 대본 보기
+        </button>
+        <button
+          className={`px-4 py-1 rounded font-semibold border ${viewMode === "regenerated" ? "bg-[#DCAC62] text-white" : "bg-white text-[#DCAC62] border-[#DCAC62]"}`}
+          onClick={() => setViewMode("regenerated")}
+        >
+          재생성 대본 보기
+        </button>
+      </div>
+    );
+  };
+
   // 뒤로가기 핸들러
   const handleGoBack = () => {
-    // store에 유효한 책 세션이 있으면 캐릭터 선택 페이지로, 없으면 메인으로
     if (isBookSessionValid() && currentBookSession) {
       navigate("/char", {
         state: {
@@ -167,6 +238,8 @@ const ScriptPage: React.FC = () => {
         {/* 래퍼: 버튼을 절대 위치시키기 위한 relative 부모 */}
         <div className="flex justify-center ml-[37.26px]">
           <div className="relative">
+            {/* 기존/재생성 대본 전환 버튼 */}
+            {renderSwitchButtons()}
             {/* 실제 컨테이너 (패딩 포함) */}
             <div
               className="
@@ -216,27 +289,67 @@ const ScriptPage: React.FC = () => {
               </div>
             </div>
 
-            {/* 절대 위치 재생성 버튼 */}
+            {/* 절대 위치 재생성 버튼 - relative로 만들어서 툴팁의 기준점으로 사용 */}
             <button
-              onClick={handleRegenerate}
-              disabled={isRegenerating}
+              onClick={handleRegenerateClick}
+              disabled={isRegenerating || regenerateUsed}
               className="
-                absolute
+                  absolute
                 bottom-[calc(100%+22px)]    /* 컨테이너 테두리 기준 22px 위 */
-                right-[15px]   /* 컨테이너 우측에서 15px 안쪽 */
-                flex items-center gap-[6px] h-[27px]
-                font-nanumGothic font-semibold text-[20px] text-black
-                cursor-pointer hover:underline transition
-                disabled:opacity-50 disabled:cursor-not-allowed
-              "
+                right-[15px] flex items-center gap-[6px] h-[27px]
+                  font-nanumGothic font-semibold text-[20px] text-black
+                  cursor-pointer hover:underline transition
+                  disabled:opacity-50 disabled:cursor-not-allowed
+                "
+              onMouseEnter={() => {
+                if (regenerateUsed) setShowTooltip(true);
+              }}
+              onMouseLeave={() => setShowTooltip(false)}
             >
               <img
                 src={Regenerating}
                 alt="재생성"
                 className={`w-[24px] h-[24px] ${isRegenerating ? "animate-spin" : ""}`}
               />
-              {isRegenerating ? "생성중..." : "재생성"}
+              <div className="relative w-0 h-0">
+                {" "}
+                {/* 툴팁: 버튼 위에 표시 */}
+                {regenerateUsed && showTooltip && (
+                  <div
+                    className="
+                    absolute bottom-full mb-2 right-0
+                    z-50 px-4 py-2 
+                    bg-white text-gray-700 text-sm 
+                    rounded shadow-lg border border-gray-200 
+                    whitespace-nowrap
+                    animate-pulse
+                  "
+                    style={{ minWidth: 220 }}
+                  >
+                    재생성은 캐릭터당 1회만 가능합니다.
+                    <div className="absolute top-full right-4 w-0 h-0 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-white"></div>
+                  </div>
+                )}
+              </div>
+              {isRegenerating
+                ? "생성중..."
+                : regenerateUsed
+                  ? "재생성 완료"
+                  : "재생성"}
             </button>
+            {/* 재생성 안내 모달 */}
+            {showRegenerateModal && (
+              <ConfirmModal
+                name={selectedName}
+                message={
+                  "대본 재생성은 캐릭터당 1회만 가능합니다. 정말 재생성 하시겠습니까?"
+                }
+                onConfirm={handleRegenerateConfirm}
+                onCancel={handleRegenerateCancel}
+                visible={showRegenerateModal}
+                confirmText="재생성"
+              />
+            )}
 
             {/* 4) 하단 버튼들 */}
             <CommonButton

--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -123,6 +123,13 @@ const ScriptPage: React.FC = () => {
     if (!currentScriptData?.scenes) {
       return fallbackScripts;
     }
+    // 짧게 대사만 넣은 버전
+    // return currentScriptData.scenes.map((scene) => {
+    //   return scene.lines.map((line) => {
+    //     return `: ${line.line_ko}`;
+    //   });
+    // });
+    // 길게 한 버전
     return currentScriptData.scenes.map((scene) => {
       const lines = scene.lines
         .map((line) => `${line.speaker}: ${line.line_ko}`)

--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -289,54 +289,64 @@ const ScriptPage: React.FC = () => {
               </div>
             </div>
 
-            {/* 절대 위치 재생성 버튼 - relative로 만들어서 툴팁의 기준점으로 사용 */}
-            <button
-              onClick={handleRegenerateClick}
-              disabled={isRegenerating || regenerateUsed}
+            {/* 절대 위치 재생성 버튼 - 마우스 이벤트를 위한 wrapper */}
+            <div
               className="
-                  absolute
+                absolute
                 bottom-[calc(100%+22px)]    /* 컨테이너 테두리 기준 22px 위 */
-                right-[15px] flex items-center gap-[6px] h-[27px]
+                right-[15px]
+              "
+              onMouseEnter={() => {
+                console.log("마우스 진입:", regenerateUsed);
+                if (regenerateUsed) setShowTooltip(true);
+              }}
+              onMouseLeave={() => {
+                console.log("마우스 나감");
+                setShowTooltip(false);
+              }}
+            >
+              <button
+                onClick={handleRegenerateClick}
+                disabled={isRegenerating || regenerateUsed}
+                className="
+                  flex items-center gap-[6px] h-[27px]
                   font-nanumGothic font-semibold text-[20px] text-black
                   cursor-pointer hover:underline transition
                   disabled:opacity-50 disabled:cursor-not-allowed
                 "
-              onMouseEnter={() => {
-                if (regenerateUsed) setShowTooltip(true);
-              }}
-              onMouseLeave={() => setShowTooltip(false)}
-            >
-              <img
-                src={Regenerating}
-                alt="재생성"
-                className={`w-[24px] h-[24px] ${isRegenerating ? "animate-spin" : ""}`}
-              />
-              <div className="relative w-0 h-0">
-                {" "}
-                {/* 툴팁: 버튼 위에 표시 */}
-                {regenerateUsed && showTooltip && (
-                  <div
-                    className="
-                    absolute bottom-full mb-2 right-0
-                    z-50 px-4 py-2 
-                    bg-white text-gray-700 text-sm 
-                    rounded shadow-lg border border-gray-200 
-                    whitespace-nowrap
-                    animate-pulse
-                  "
-                    style={{ minWidth: 220 }}
-                  >
-                    재생성은 캐릭터당 1회만 가능합니다.
-                    <div className="absolute top-full right-4 w-0 h-0 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-white"></div>
-                  </div>
-                )}
-              </div>
-              {isRegenerating
-                ? "생성중..."
-                : regenerateUsed
-                  ? "재생성 완료"
-                  : "재생성"}
-            </button>
+              >
+                <img
+                  src={Regenerating}
+                  alt="재생성"
+                  className={`w-[24px] h-[24px] ${isRegenerating ? "animate-spin" : ""}`}
+                />
+                <div className="relative">
+                  {isRegenerating
+                    ? "생성중..."
+                    : regenerateUsed
+                      ? "재생성 완료"
+                      : "재생성"}
+
+                  {/* 툴팁: regenerateUsed일 때만 렌더링, showTooltip으로 애니메이션 제어 */}
+                  {regenerateUsed && (
+                    <div
+                      className={`
+                        absolute bottom-[200%] translate-x-[-50%] bg-white flex justify-center items-center px-5 text-left text-base font-normal text-black w-[20rem] h-[5rem] rounded-[1.25rem] shadow-[0px_4px_8px_rgba(0,0,0,0.25)] z-[1] 
+                        after:absolute after:bottom-[-0.9rem] after:left-1/2 after:translate-x-[-50%] after:content-[''] after:border-l-[0.625rem] after:border-l-transparent after:border-r-[0.625rem] after:border-r-transparent after:border-t-[1rem] after:border-t-white after:z-[2]
+                        transition-all duration-300 ease-in-out transform
+                        ${
+                          showTooltip
+                            ? "opacity-100 scale-100 translate-y-0"
+                            : "opacity-0 scale-95 translate-y-1"
+                        }
+                      `}
+                    >
+                      재생성은 캐릭터당 1회만 가능합니다.
+                    </div>
+                  )}
+                </div>
+              </button>
+            </div>
             {/* 재생성 안내 모달 */}
             {showRegenerateModal && (
               <ConfirmModal

--- a/src/pages/ScriptPage.tsx
+++ b/src/pages/ScriptPage.tsx
@@ -10,11 +10,16 @@ import CommonButton from "../components/CommonButton";
 import BackIcon from "../assets/Icons/BackIcon.svg";
 import VideoIcon from "../assets/Icons/VideoIcon.svg"; // 영상 생성 아이콘
 import { createScript, type ScriptApiResponse } from "../api/characterApi";
+import { useAppStore } from "../stores/appStore";
 
 const ScriptPage: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const [isRegenerating, setIsRegenerating] = useState(false);
+
+  // Zustand store 사용
+  const { currentBookSession, isBookSessionValid, setScriptCache } =
+    useAppStore();
 
   // CharacterSelectPage에서 전달받은 데이터
   const { scriptData, characterName } =
@@ -46,16 +51,31 @@ const ScriptPage: React.FC = () => {
     허나, 나는 안다. 그 어명이 누구의 입에서 나왔는지를.`,
   ];
 
-  // 스크립트 데이터가 없으면 캐릭터 선택 페이지로 리다이렉트
+  // 스크립트 데이터를 store에 저장 (처음 마운트될 때)
+  useEffect(() => {
+    if (currentScriptData && characterName) {
+      // 스크립트 데이터를 캐시에 저장
+      setScriptCache(
+        currentScriptData.characterId,
+        characterName,
+        currentScriptData
+      );
+    }
+  }, [currentScriptData, characterName, setScriptCache]);
+
+  // 스크립트 데이터가 없으면 적절한 페이지로 리다이렉트
   useEffect(() => {
     if (!currentScriptData) {
-      console.warn(
-        "스크립트 데이터가 없습니다. 캐릭터 선택 페이지로 이동합니다."
-      );
-      // 개발 중에는 fallback 데이터 사용, 실제로는 아래 주석을 해제
-      // navigate("/character-select");
+      console.warn("스크립트 데이터가 없습니다.");
+
+      // store에 유효한 책 세션이 있으면 캐릭터 선택 페이지로, 없으면 메인으로
+      if (isBookSessionValid()) {
+        navigate("/char");
+      } else {
+        navigate("/");
+      }
     }
-  }, [currentScriptData, navigate]);
+  }, [currentScriptData, navigate, isBookSessionValid]);
 
   // API 응답에서 스크립트 텍스트 추출
   const getScriptsFromData = () => {
@@ -84,11 +104,32 @@ const ScriptPage: React.FC = () => {
     try {
       const newScriptData = await createScript(currentScriptData.characterId);
       setCurrentScriptData(newScriptData);
+
+      // 새로 생성된 스크립트를 캐시에 업데이트
+      if (characterName) {
+        setScriptCache(newScriptData.characterId, characterName, newScriptData);
+      }
     } catch (error) {
       console.error("스크립트 재생성 실패:", error);
       alert("스크립트 재생성에 실패했습니다. 다시 시도해주세요.");
     } finally {
       setIsRegenerating(false);
+    }
+  };
+
+  // 뒤로가기 핸들러
+  const handleGoBack = () => {
+    // store에 유효한 책 세션이 있으면 캐릭터 선택 페이지로, 없으면 메인으로
+    if (isBookSessionValid() && currentBookSession) {
+      navigate("/char", {
+        state: {
+          characters: currentBookSession.characters,
+          bookTitle: currentBookSession.bookTitle,
+          bookId: currentBookSession.bookId,
+        },
+      });
+    } else {
+      navigate("/");
     }
   };
 
@@ -206,7 +247,7 @@ const ScriptPage: React.FC = () => {
                   className="w-[20px] h-[20px]"
                 />
               }
-              onClick={() => navigate("/character-select")}
+              onClick={handleGoBack}
               className="
                 absolute
                 top-[calc(100%+19px)]                 /* 컨테이너 아래에서 19px 아래 */

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -21,8 +21,14 @@ interface BookSession {
 
 interface ScriptCache {
   [characterId: number]: {
-    data: ScriptApiResponse;
-    cachedAt: number; // 캐시된 시간
+    original: {
+      data: ScriptApiResponse;
+      cachedAt: number;
+    };
+    regenerated?: {
+      data: ScriptApiResponse;
+      cachedAt: number;
+    };
     characterName: string;
   };
 }
@@ -46,9 +52,13 @@ interface AppState {
   setScriptCache: (
     characterId: number,
     characterName: string,
-    scriptData: ScriptApiResponse
+    scriptData: ScriptApiResponse,
+    isRegenerated?: boolean
   ) => void;
-  getScriptCache: (characterId: number) => ScriptApiResponse | null;
+  getScriptCache: (characterId: number) => {
+    original: ScriptApiResponse | null;
+    regenerated: ScriptApiResponse | null;
+  };
   clearExpiredScripts: () => void;
   clearAllScripts: () => void;
 
@@ -82,35 +92,84 @@ export const useAppStore = create<AppState>()(
         set({ currentBookSession: null });
       },
 
-      setScriptCache: (characterId, characterName, scriptData) => {
-        set((state) => ({
-          scriptCache: {
-            ...state.scriptCache,
-            [characterId]: {
-              data: scriptData,
-              cachedAt: Date.now(),
-              characterName,
-            },
-          },
-        }));
+      setScriptCache: (
+        characterId,
+        characterName,
+        scriptData,
+        isRegenerated = false
+      ) => {
+        set((state) => {
+          const existingCache = state.scriptCache[characterId];
+          const now = Date.now();
+
+          if (isRegenerated) {
+            // 재생성된 대본 저장
+            return {
+              scriptCache: {
+                ...state.scriptCache,
+                [characterId]: {
+                  ...existingCache,
+                  regenerated: {
+                    data: scriptData,
+                    cachedAt: now,
+                  },
+                  characterName,
+                },
+              },
+            };
+          } else {
+            // 원본 대본 저장
+            return {
+              scriptCache: {
+                ...state.scriptCache,
+                [characterId]: {
+                  original: {
+                    data: scriptData,
+                    cachedAt: now,
+                  },
+                  regenerated: existingCache?.regenerated, // 기존 재생성 대본 유지
+                  characterName,
+                },
+              },
+            };
+          }
+        });
       },
 
       getScriptCache: (characterId) => {
         const cache = get().scriptCache[characterId];
-        if (!cache) return null;
+        if (!cache) return { original: null, regenerated: null };
 
-        // 만료 확인
-        if (!get().isScriptCacheValid(characterId)) {
-          // 만료된 캐시 삭제
+        const now = Date.now();
+        let original: ScriptApiResponse | null = null;
+        let regenerated: ScriptApiResponse | null = null;
+
+        // 원본 대본 유효성 확인
+        if (
+          cache.original &&
+          now - cache.original.cachedAt < SCRIPT_CACHE_EXPIRY
+        ) {
+          original = cache.original.data;
+        }
+
+        // 재생성된 대본 유효성 확인
+        if (
+          cache.regenerated &&
+          now - cache.regenerated.cachedAt < SCRIPT_CACHE_EXPIRY
+        ) {
+          regenerated = cache.regenerated.data;
+        }
+
+        // 둘 다 만료된 경우 캐시 삭제
+        if (!original && !regenerated) {
           set((state) => {
             const newCache = { ...state.scriptCache };
             delete newCache[characterId];
             return { scriptCache: newCache };
           });
-          return null;
         }
 
-        return cache.data;
+        return { original, regenerated };
       },
 
       clearExpiredScripts: () => {
@@ -118,8 +177,28 @@ export const useAppStore = create<AppState>()(
         set((state) => {
           const newCache: ScriptCache = {};
           Object.entries(state.scriptCache).forEach(([characterId, cache]) => {
-            if (now - cache.cachedAt < SCRIPT_CACHE_EXPIRY) {
-              newCache[Number(characterId)] = cache;
+            const validOriginal =
+              cache.original &&
+              now - cache.original.cachedAt < SCRIPT_CACHE_EXPIRY;
+            const validRegenerated =
+              cache.regenerated &&
+              now - cache.regenerated.cachedAt < SCRIPT_CACHE_EXPIRY;
+
+            if (validOriginal || validRegenerated) {
+              const newCacheEntry: Partial<ScriptCache[number]> = {
+                characterName: cache.characterName,
+              };
+
+              if (validOriginal) {
+                newCacheEntry.original = cache.original;
+              }
+
+              if (validRegenerated) {
+                newCacheEntry.regenerated = cache.regenerated;
+              }
+
+              newCache[Number(characterId)] =
+                newCacheEntry as ScriptCache[number];
             }
           });
           return { scriptCache: newCache };
@@ -143,7 +222,15 @@ export const useAppStore = create<AppState>()(
         if (!cache) return false;
 
         const now = Date.now();
-        return now - cache.cachedAt < SCRIPT_CACHE_EXPIRY;
+        const validOriginal = Boolean(
+          cache.original && now - cache.original.cachedAt < SCRIPT_CACHE_EXPIRY
+        );
+        const validRegenerated = Boolean(
+          cache.regenerated &&
+            now - cache.regenerated.cachedAt < SCRIPT_CACHE_EXPIRY
+        );
+
+        return validOriginal || validRegenerated;
       },
     }),
     {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,0 +1,172 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { ScriptApiResponse } from "../api/characterApi";
+
+// scenes를 제외한 최소 캐릭터 타입
+export type MinimalCharacter = {
+  id: number;
+  characterName: string;
+  isMain: boolean;
+  age: number;
+  gender: string;
+  characterDescription: string;
+};
+
+interface BookSession {
+  bookId: number;
+  bookTitle: string;
+  characters: MinimalCharacter[];
+  selectedAt: number; // 선택된 시간 (만료 확인용)
+}
+
+interface ScriptCache {
+  [characterId: number]: {
+    data: ScriptApiResponse;
+    cachedAt: number; // 캐시된 시간
+    characterName: string;
+  };
+}
+
+interface AppState {
+  // 현재 선택된 책과 캐릭터 세션
+  currentBookSession: BookSession | null;
+
+  // 스크립트 캐시 (캐릭터별)
+  scriptCache: ScriptCache;
+
+  // Actions
+  setBookSession: (
+    bookId: number,
+    bookTitle: string,
+    characters: MinimalCharacter[]
+  ) => void;
+  clearBookSession: () => void;
+
+  // 스크립트 캐시 관리
+  setScriptCache: (
+    characterId: number,
+    characterName: string,
+    scriptData: ScriptApiResponse
+  ) => void;
+  getScriptCache: (characterId: number) => ScriptApiResponse | null;
+  clearExpiredScripts: () => void;
+  clearAllScripts: () => void;
+
+  // 유틸리티
+  isBookSessionValid: () => boolean;
+  isScriptCacheValid: (characterId: number) => boolean;
+}
+
+// 만료 시간 설정 (밀리초)
+const BOOK_SESSION_EXPIRY = 2 * 60 * 60 * 1000; // 2시간
+const SCRIPT_CACHE_EXPIRY = 1 * 60 * 60 * 1000; // 1시간
+
+export const useAppStore = create<AppState>()(
+  persist(
+    (set, get) => ({
+      currentBookSession: null,
+      scriptCache: {},
+
+      setBookSession: (bookId, bookTitle, characters) => {
+        set({
+          currentBookSession: {
+            bookId,
+            bookTitle,
+            characters,
+            selectedAt: Date.now(),
+          },
+        });
+      },
+
+      clearBookSession: () => {
+        set({ currentBookSession: null });
+      },
+
+      setScriptCache: (characterId, characterName, scriptData) => {
+        set((state) => ({
+          scriptCache: {
+            ...state.scriptCache,
+            [characterId]: {
+              data: scriptData,
+              cachedAt: Date.now(),
+              characterName,
+            },
+          },
+        }));
+      },
+
+      getScriptCache: (characterId) => {
+        const cache = get().scriptCache[characterId];
+        if (!cache) return null;
+
+        // 만료 확인
+        if (!get().isScriptCacheValid(characterId)) {
+          // 만료된 캐시 삭제
+          set((state) => {
+            const newCache = { ...state.scriptCache };
+            delete newCache[characterId];
+            return { scriptCache: newCache };
+          });
+          return null;
+        }
+
+        return cache.data;
+      },
+
+      clearExpiredScripts: () => {
+        const now = Date.now();
+        set((state) => {
+          const newCache: ScriptCache = {};
+          Object.entries(state.scriptCache).forEach(([characterId, cache]) => {
+            if (now - cache.cachedAt < SCRIPT_CACHE_EXPIRY) {
+              newCache[Number(characterId)] = cache;
+            }
+          });
+          return { scriptCache: newCache };
+        });
+      },
+
+      clearAllScripts: () => {
+        set({ scriptCache: {} });
+      },
+
+      isBookSessionValid: () => {
+        const session = get().currentBookSession;
+        if (!session) return false;
+
+        const now = Date.now();
+        return now - session.selectedAt < BOOK_SESSION_EXPIRY;
+      },
+
+      isScriptCacheValid: (characterId) => {
+        const cache = get().scriptCache[characterId];
+        if (!cache) return false;
+
+        const now = Date.now();
+        return now - cache.cachedAt < SCRIPT_CACHE_EXPIRY;
+      },
+    }),
+    {
+      name: "vlog-app-storage", // sessionStorage key name
+      storage: createJSONStorage(() => sessionStorage),
+
+      // 성능 최적화: 스토리지에서 불러올 때 만료된 데이터 정리
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          // 만료된 북 세션 확인
+          if (!state.isBookSessionValid()) {
+            state.clearBookSession();
+          }
+
+          // 만료된 스크립트 캐시 정리
+          state.clearExpiredScripts();
+
+          console.log("🔄 Store rehydrated with optimizations:", {
+            hasValidSession: state.isBookSessionValid(),
+            scriptCacheSize: Object.keys(state.scriptCache).length,
+          });
+        }
+      },
+    }
+  )
+);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) 대본 생성 페이지 API 연동 #50 

## 📝작업 내용

> 대본 생성 페이지 API 연동
전반적인 UX개선
캐싱 시스템 구축

- POST `/characters/{characterId}/scripts` 연동
    - CharacterSelectPage에서 "대본작성하기" 버튼 클릭 시 /characters/{characterId}/script/ API 호출
    - API 응답 구조에 맞춰 ScriptApiResponse 인터페이스 정의
- 대본 재생성 API 연동
- 대본 재생성 UI 수정 (생성 중임을 보여주도록 개선)
- 페이지 간 이동 시 데이터 유지를 위한 전역 상태 관리
    - 인물 선택 페이지로 돌아가도 캐시를 이용해 대본을 생성한 인물에 대해서는 추가적인 요청 없이 다시 볼 수 있도록 최적화
    - sessionStorage persist 기능으로 새로고침 시에도 상태 유지
    - 북 세션(2시간)과 스크립트 캐시(1시간) TTL 기반 만료 처리
- UX 개선 : 메인으로 갈 때는 대본 정보가 삭제될 수 있음을 안내하는 모달 구현

### 결정된 사항
- 조회 API는 만들지 않기도했고, redis 상에서 대본이 조회가 어려운 문제가 있었지만, redis를 DB 부하를 줄이기 위한 목적으로 사용했기에 조회api를 추가로 만들지는 않기로 결정