### PR TITLE
[Fix] 책 캐러셀 UX 개선

### DIFF
--- a/src/components/BooksSection.tsx
+++ b/src/components/BooksSection.tsx
@@ -26,19 +26,17 @@ const BooksSection: React.FC<BooksSectionProps> = ({
   const [isAnimating, setIsAnimating] = useState(false);
   const carouselRef = useRef<HTMLDivElement>(null);
 
-  // 한 화면에 보여질 책의 개수
   const booksPerSlide = 5;
-  const totalSlides = Math.ceil(
-    (books.length + (onAddBook ? 1 : 0)) / booksPerSlide
-  );
+  const totalSlides = Math.max(1, Math.ceil(books.length / booksPerSlide));
 
-  // 선택된 책이 있는 슬라이드로 자동 이동
+  // 🌟 여기가 최종 수정 지점입니다 🌟
+  // 선택된 책이 바뀔 때만 이 효과가 실행되도록 의존성 배열에서 currentSlide를 제거합니다.
   useEffect(() => {
     const targetSlide = Math.floor(selectedIndex / booksPerSlide);
     if (targetSlide !== currentSlide) {
       setCurrentSlide(targetSlide);
     }
-  }, [selectedIndex, currentSlide, booksPerSlide]);
+  }, [selectedIndex, booksPerSlide]); // ✅ currentSlide 제거
 
   const handlePrevSlide = () => {
     if (isAnimating) return;
@@ -58,27 +56,9 @@ const BooksSection: React.FC<BooksSectionProps> = ({
     onBookSelect(index);
   };
 
-  // 현재 슬라이드에서 보여질 책들 계산
-  const getCurrentSlideBooks = () => {
-    const startIndex = currentSlide * booksPerSlide;
-    const endIndex = Math.min(startIndex + booksPerSlide, books.length);
-    const currentBooks = books.slice(startIndex, endIndex);
-
-    // 책 추가 버튼을 마지막 슬라이드에 포함
-    const shouldShowAddButton =
-      onAddBook && (currentSlide === totalSlides - 1 || books.length === 0);
-
-    return { currentBooks, shouldShowAddButton, startIndex };
-  };
-
-  const { currentBooks, shouldShowAddButton, startIndex } =
-    getCurrentSlideBooks();
-
   return (
     <div className="relative w-full fade-in-up">
-      {/* 캐러셀 컨테이너 */}
       <div className="relative overflow-hidden">
-        {/* 네비게이션 버튼 - 이전 */}
         {totalSlides > 1 && (
           <button
             onClick={handlePrevSlide}
@@ -100,8 +80,6 @@ const BooksSection: React.FC<BooksSectionProps> = ({
             </svg>
           </button>
         )}
-
-        {/* 네비게이션 버튼 - 다음 */}
         {totalSlides > 1 && (
           <button
             onClick={handleNextSlide}
@@ -124,137 +102,113 @@ const BooksSection: React.FC<BooksSectionProps> = ({
           </button>
         )}
 
-        {/* 책 컨테이너 */}
         <div
           ref={carouselRef}
-          className="carousel-container flex justify-center p-10 pb-0 items-end min-h-[500px] gpu-accelerated"
+          className="flex transition-transform duration-500 ease-in-out"
           style={{
             transform: `translateX(-${currentSlide * 100}%)`,
-            transition: isAnimating
-              ? "transform 0.5s cubic-bezier(0.4, 0, 0.2, 1)"
-              : "none",
           }}
         >
-          {/* 고정된 컨테이너로 책들 감싸기 */}
-          <div className="flex items-end justify-center gap-8 relative">
-            {currentBooks.map((book, index) => {
-              const actualIndex = startIndex + index;
-              const isSelected = actualIndex === selectedIndex;
-
-              return (
-                <div
-                  key={book.id}
-                  className="relative flex flex-col items-center group cursor-pointer"
-                  onClick={() => handleBookClick(actualIndex)}
-                >
-                  {/* 책 컨테이너 - 고정된 크기로 레이아웃 안정성 확보 */}
-                  <div className="relative flex items-end justify-center">
-                    {/* 선택한 책 뒤에 나타내는 링인데 별론 거 같음 */}
-                    {/* {isSelected && (
-                      <div className="absolute inset-0 flex items-center justify-center z-10">
-                        <div
-                          className="selection-ring rounded-lg border-4 border-[#DCAC62] bg-[#DCAC62]/10"
-                          style={{
-                            width: "280px",
-                            height: "380px",
-                          }}
-                        />
-                      </div>
-                    )}  */}
-
-                    {/* 책 썸네일 */}
+          {Array.from({ length: totalSlides }).map((_, pageIndex) => (
+            <div
+              key={pageIndex}
+              className="flex items-end justify-center gap-8 p-10 pb-0 min-h-[500px]"
+              style={{ minWidth: "100%", flexShrink: 0 }}
+            >
+              {books
+                .slice(
+                  pageIndex * booksPerSlide,
+                  (pageIndex + 1) * booksPerSlide
+                )
+                .map((book, bookIndex) => {
+                  const actualIndex = pageIndex * booksPerSlide + bookIndex;
+                  const isSelected = actualIndex === selectedIndex;
+                  return (
                     <div
-                      className={`book-container relative z-20 ${isSelected ? "selected book-shadow-selected" : "book-shadow-normal"}`}
+                      key={book.id}
+                      className="relative flex flex-col items-center group cursor-pointer"
+                      onClick={() => handleBookClick(actualIndex)}
                     >
-                      <BookThumbnail
-                        src={book.src}
-                        alt={book.alt}
-                        width={220}
-                        height={320}
-                        shadow={
-                          isSelected
-                            ? "0 25px 50px rgba(220,172,98,0.4)"
-                            : "0 10px 25px rgba(0,0,0,0.15)"
-                        }
-                      />
+                      <div className="relative flex items-end justify-center">
+                        <div
+                          className={`book-container relative z-20 ${isSelected ? "selected book-shadow-selected" : "book-shadow-normal"}`}
+                        >
+                          <BookThumbnail
+                            src={book.src}
+                            alt={book.alt}
+                            width={220}
+                            height={320}
+                            shadow={
+                              isSelected
+                                ? "0 25px 50px rgba(220,172,98,0.4)"
+                                : "0 10px 25px rgba(0,0,0,0.15)"
+                            }
+                          />
+                        </div>
+                      </div>
+                      <div className="mt-4 text-center max-w-[200px]">
+                        <p
+                          className={`font-medium transition-all duration-[400ms] ease-out line-clamp-2 ${isSelected ? "text-[#604317] text-lg font-bold" : "text-gray-700 text-base group-hover:text-[#604317]"}`}
+                        >
+                          {book.title}
+                        </p>
+                      </div>
+                      {isSelected && (
+                        <div className="mt-2 w-2 h-2 bg-[#DCAC62] rounded-full animate-bounce" />
+                      )}
+                    </div>
+                  );
+                })}
+
+              {onAddBook && pageIndex === totalSlides - 1 && (
+                <div
+                  className="relative flex flex-col items-center group cursor-pointer"
+                  onClick={onAddBook}
+                >
+                  <div className="relative flex items-end justify-center">
+                    <div className="book-container relative z-20 book-shadow-normal">
+                      <div
+                        className="gradient-background flex flex-col items-center justify-center border-2 border-dashed border-[#DCAC62] transition-all duration-300 rounded-lg backdrop-blur-sm"
+                        style={{
+                          width: 220,
+                          height: 320,
+                          boxShadow: "0 10px 25px rgba(0,0,0,0.15)",
+                        }}
+                      >
+                        <div className="icon-background w-16 h-16 rounded-full flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
+                          <svg
+                            className="w-8 h-8 text-[#DCAC62] group-hover:text-[#B8941F] transition-colors duration-300"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2.5}
+                              d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                            />
+                          </svg>
+                        </div>
+                        <p className="text-[#75624E] font-medium text-center px-6 leading-relaxed group-hover:text-[#604317] transition-colors duration-300">
+                          새 책<br />
+                          추가하기
+                        </p>
+                      </div>
                     </div>
                   </div>
-
-                  {/* 책 제목 */}
                   <div className="mt-4 text-center max-w-[200px]">
-                    <p
-                      className={`
-                      font-medium transition-all duration-[400ms] ease-out line-clamp-2
-                      ${
-                        isSelected
-                          ? "text-[#604317] text-lg font-bold"
-                          : "text-gray-700 text-base group-hover:text-[#604317]"
-                      }
-                    `}
-                    >
-                      {book.title}
+                    <p className="text-gray-600 text-base group-hover:text-[#604317] transition-colors duration-300">
+                      새로운 이야기
                     </p>
                   </div>
-
-                  {/* 선택 표시 점 */}
-                  {isSelected && (
-                    <div className="mt-2 w-2 h-2 bg-[#DCAC62] rounded-full animate-bounce" />
-                  )}
                 </div>
-              );
-            })}
-
-            {/* 책 추가 버튼 */}
-            {shouldShowAddButton && (
-              <div
-                className="relative flex flex-col items-center group cursor-pointer"
-                onClick={onAddBook}
-              >
-                <div className="relative flex items-end justify-center">
-                  <div className="book-container relative z-20 book-shadow-normal">
-                    <div
-                      className="gradient-background flex flex-col items-center justify-center border-2 border-dashed border-[#DCAC62] transition-all duration-300 rounded-lg backdrop-blur-sm"
-                      style={{
-                        width: 220,
-                        height: 320,
-                        boxShadow: "0 10px 25px rgba(0,0,0,0.15)",
-                      }}
-                    >
-                      <div className="icon-background w-16 h-16 rounded-full flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
-                        <svg
-                          className="w-8 h-8 text-[#DCAC62] group-hover:text-[#B8941F] transition-colors duration-300"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2.5}
-                            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-                          />
-                        </svg>
-                      </div>
-                      <p className="text-[#75624E] font-medium text-center px-6 leading-relaxed group-hover:text-[#604317] transition-colors duration-300">
-                        새 책<br />
-                        추가하기
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="mt-4 text-center max-w-[200px]">
-                  <p className="text-gray-600 text-base group-hover:text-[#604317] transition-colors duration-300">
-                    새로운 이야기
-                  </p>
-                </div>
-              </div>
-            )}
-          </div>
+              )}
+            </div>
+          ))}
         </div>
       </div>
 
-      {/* 슬라이드 인디케이터 */}
       {totalSlides > 1 && (
         <div className="flex justify-center mt-8 gap-3">
           {Array.from({ length: totalSlides }).map((_, index) => (
@@ -262,9 +216,7 @@ const BooksSection: React.FC<BooksSectionProps> = ({
               key={index}
               onClick={() => !isAnimating && setCurrentSlide(index)}
               disabled={isAnimating}
-              className={`slide-indicator w-3 h-3 rounded-full disabled:cursor-not-allowed ${
-                index === currentSlide ? "active" : "bg-gray-300"
-              }`}
+              className={`slide-indicator w-3 h-3 rounded-full disabled:cursor-not-allowed ${index === currentSlide ? "active" : "bg-gray-300"}`}
             />
           ))}
         </div>

--- a/src/pages/MyLibraryPage.tsx
+++ b/src/pages/MyLibraryPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import BooksSection from "../components/BooksSection";
 import BookUploadModal from "../components/BookUploadModal";
@@ -67,6 +67,7 @@ const MyLibraryPage: React.FC = () => {
   // 책 업로드 모달 상태
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [isUploadLoading, setIsUploadLoading] = useState(false);
+  const [searchTerm, setSearchTerm] = useState(""); // 검색어 상태
 
   // 책 목록 데이터
   const [books, setBooks] = useState<Book[]>([]);
@@ -113,6 +114,20 @@ const MyLibraryPage: React.FC = () => {
       fetchBooks();
     }
   }, [authLoading, isAuthenticated]); // 의존성 배열이 빈 배열이 컴포넌트 마운트 시에만 실행
+
+  // const filteredBooks = () => {
+  //   if (!searchTerm) return books; // 검색어가 없으면 전체 목록 반환
+  //   return books.filter((book) =>
+  //     book.title.toLowerCase().includes(searchTerm.toLowerCase())
+  //   );
+  // }
+  // useMemo로 성능 최적화
+  const filteredBooks = useMemo(() => {
+    if (!searchTerm) return books; // 검색어가 없으면 전체 목록 반환
+    return books.filter((book) =>
+      book.title.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+  }, [books, searchTerm]);
 
   // 현재 선택된 책 객체
   const selectedBook = books[selectedBookIndex];
@@ -369,6 +384,8 @@ const MyLibraryPage: React.FC = () => {
                   type="text"
                   placeholder="작품명으로 검색"
                   className="w-full bg-[#E4E4E4] px-4 py-3 pr-10 rounded-full text-[16px] text-[#9F9494] focus:outline-none"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
                 />
                 <img
                   src={SearchIcon}
@@ -422,7 +439,7 @@ const MyLibraryPage: React.FC = () => {
               </div>
             ) : (
               <BooksSection
-                books={books}
+                books={filteredBooks}
                 selectedIndex={selectedBookIndex}
                 onBookSelect={setSelectedBookIndex}
                 onAddBook={() => setIsUploadModalOpen(true)}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) 책 캐래설 UX 개선 #76 

## 📝작업 내용

> 책 검색 기능 구현, 책 캐러셀이 책이 5개가 넘어갈 경우 페이지가 안넘어가고, '새 책 추가하기' 버튼도 누를 수 없던 오류 수정
- js include함수로 검색 기능 구현 (by 제목)
    - useMemo를 사용하여 불필요한 렌더링이 일어나지않게 최적화
- **책 캐러셀 로직 리팩토링 및 오류 수정**
  - **(문제)** 기존에는 현재 페이지만 렌더링하여 내용만 교체하는 방식이라, 페이지 이동 시 깜빡임 현상이 발생하고 실제 페이지 이동이 불가능했음
  - **(해결)** 모든 페이지를 미리 렌더링하여 `display: flex` 컨테이너에 배치하고, `transform: translateX()` 속성으로 전체 컨테이너를 이동시키는 방식으로 변경하여 **부드러운 슬라이드 애니메이션 구현**
  - **(문제)** `useEffect` 의존성 문제로, 사용자가 슬라이드를 넘겨도 선택된 책의 원래 위치로 강제 복귀하는 버그 발생
  - **(해결)** `useEffect` 의존성 배열에서 `currentSlide`를 제거하여 **사용자 입력(버튼 클릭)과 상태 동기화 로직의 충돌을 해결**

### 스크린샷 (선택)
검색 기능
![화면 기록 2025-07-30 오전 2 57 20](https://github.com/user-attachments/assets/5833d4e1-c424-4a14-b0a1-22d2c2892e5c)


캐러셀UX 개선

![화면 기록 2025-07-30 오전 3 05 02](https://github.com/user-attachments/assets/f2df3c34-18b4-4975-ac90-1d63c2e22211)


